### PR TITLE
feat(web): minimal runner stage-1 with arcade physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ pnpm dev
 - Web-App erreichbar unter [http://localhost:5173](http://localhost:5173)
 - API erreichbar unter [http://localhost:3000](http://localhost:3000)
 
+### Web starten
+
+```bash
+pnpm --filter web dev
+```
+
+- Steuerung: Links/Rechts über `A`/`D` oder Pfeiltasten, Sprung via `Leertaste` oder `Pfeil nach oben`, `Esc` pausiert.
+- Ziel: Laufe zum Ausgang, weiche Gefahren aus und erreiche das Levelende so schnell wie möglich.
+
 ## Docker-Entwicklung
 ```bash
 docker compose up --build

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,9 +4,22 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Infinite Runner SaaS</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background-color: #0f172a;
+      }
+
+      #game-container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="game-container"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --check \"src/**/*.{ts,tsx,css,html}\""
   },
-  "dependencies": {},
+  "dependencies": {
+    "phaser": "3"
+  },
   "devDependencies": {
     "@types/node": "^20.10.6",
     "typescript": "^5.3.3",

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,10 +1,34 @@
-const root = document.getElementById('app');
+import Phaser from 'phaser';
 
-if (root) {
-  root.innerHTML = `
-    <main style="font-family: system-ui, sans-serif; padding: 2rem;">
-      <h1>Infinite Runner SaaS Web</h1>
-      <p>Vite + TypeScript placeholder. Game UI kommt später.</p>
-    </main>
-  `;
-}
+import { BootScene } from './scenes/BootScene';
+import { GameScene } from './scenes/GameScene';
+import { RUNNER_CONSTANTS } from './types/game';
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  parent: 'game-container',
+  backgroundColor: '#0f172a',
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 960,
+    height: 540,
+  },
+  pixelArt: true,
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: RUNNER_CONSTANTS.gravityY },
+      debug: false,
+    },
+  },
+  fps: {
+    target: 60,
+    forceSetTimeOut: true,
+    smoothStep: true,
+  },
+  scene: [BootScene, GameScene],
+};
+
+// eslint-disable-next-line no-new
+new Phaser.Game(config);

--- a/apps/web/src/scenes/BootScene.ts
+++ b/apps/web/src/scenes/BootScene.ts
@@ -1,0 +1,31 @@
+import Phaser from 'phaser';
+
+const TEXTURES: Array<{ key: string; width: number; height: number; color: number }>
+  = [
+    { key: 'player', width: 48, height: 64, color: 0x38bdf8 },
+    { key: 'platform', width: 64, height: 16, color: 0x1e293b },
+    { key: 'hazard', width: 64, height: 16, color: 0xef4444 },
+    { key: 'exit', width: 32, height: 64, color: 0x22c55e },
+  ];
+
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super('boot');
+  }
+
+  create(): void {
+    TEXTURES.forEach((texture) => {
+      if (this.textures.exists(texture.key)) {
+        return;
+      }
+
+      const graphics = this.add.graphics();
+      graphics.fillStyle(texture.color, 1);
+      graphics.fillRect(0, 0, texture.width, texture.height);
+      graphics.generateTexture(texture.key, texture.width, texture.height);
+      graphics.destroy();
+    });
+
+    this.scene.start('game');
+  }
+}

--- a/apps/web/src/scenes/GameScene.ts
+++ b/apps/web/src/scenes/GameScene.ts
@@ -1,0 +1,273 @@
+import Phaser from 'phaser';
+
+import { LevelDefinition, RUNNER_CONSTANTS, RectangleSpec } from '../types/game';
+
+const LEVEL_DATA: LevelDefinition = {
+  name: 'Demo-01',
+  world: { width: 4000, height: 720 },
+  groundY: 620,
+  platforms: [
+    { x: 0, y: 620, w: 1200, h: 40 },
+    { x: 1350, y: 560, w: 220, h: 24 },
+    { x: 1700, y: 520, w: 220, h: 24 },
+    { x: 2050, y: 480, w: 220, h: 24 },
+    { x: 2500, y: 620, w: 800, h: 40 },
+    { x: 3450, y: 560, w: 220, h: 24 },
+  ],
+  hazards: [
+    { x: 1200, y: 600, w: 120, h: 20 },
+    { x: 3300, y: 600, w: 120, h: 20 },
+  ],
+  exit: { x: 3800, y: 560, w: 40, h: 80 },
+};
+
+type StaticSprite = Phaser.Physics.Arcade.Sprite & {
+  body: Phaser.Physics.Arcade.StaticBody;
+};
+
+type DynamicSprite = Phaser.Physics.Arcade.Sprite & {
+  body: Phaser.Physics.Arcade.Body;
+};
+
+export class GameScene extends Phaser.Scene {
+  private player!: DynamicSprite;
+  private platforms!: Phaser.Physics.Arcade.StaticGroup;
+  private hazards!: Phaser.Physics.Arcade.StaticGroup;
+  private exitZone!: StaticSprite;
+
+  private hudText!: Phaser.GameObjects.Text;
+  private pauseOverlay!: Phaser.GameObjects.Text;
+
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+  private keyA!: Phaser.Input.Keyboard.Key;
+  private keyD!: Phaser.Input.Keyboard.Key;
+  private spaceKey!: Phaser.Input.Keyboard.Key;
+  private pauseKey!: Phaser.Input.Keyboard.Key;
+  private jumpKeys: Phaser.Input.Keyboard.Key[] = [];
+
+  private lastGroundedAt = Number.NEGATIVE_INFINITY;
+  private jumpBufferedAt = Number.NEGATIVE_INFINITY;
+
+  private levelStartTime = 0;
+  private pauseStartedAt = 0;
+  private accumulatedPauseTime = 0;
+  private isPaused = false;
+
+  constructor() {
+    super('game');
+  }
+
+  create(): void {
+    this.setupInput();
+    this.setupLevel();
+    this.setupPlayer();
+    this.setupCamera();
+    this.setupHud();
+
+    this.levelStartTime = this.time.now;
+    this.pauseStartedAt = 0;
+    this.accumulatedPauseTime = 0;
+    this.isPaused = false;
+  }
+
+  update(time: number): void {
+    this.handlePauseToggle(time);
+    this.updateHud(time);
+
+    if (this.isPaused) {
+      return;
+    }
+
+    this.processMovement(time);
+    this.checkFailState();
+  }
+
+  private setupInput(): void {
+    this.cursors = this.input.keyboard.createCursorKeys();
+    this.keyA = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.A);
+    this.keyD = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D);
+    this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    this.pauseKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+
+    const maybeKeys: Array<Phaser.Input.Keyboard.Key | undefined> = [
+      this.cursors.up,
+      this.spaceKey,
+    ];
+
+    this.jumpKeys = maybeKeys.filter((key): key is Phaser.Input.Keyboard.Key => key !== undefined);
+  }
+
+  private setupLevel(): void {
+    const { world } = LEVEL_DATA;
+    this.physics.world.setBounds(0, 0, world.width, world.height);
+    this.physics.world.setBoundsCollision(true, true, true, false);
+
+    this.platforms = this.physics.add.staticGroup();
+    LEVEL_DATA.platforms.forEach((platform) => this.spawnStaticTile(platform, 'platform', this.platforms));
+
+    this.hazards = this.physics.add.staticGroup();
+    LEVEL_DATA.hazards.forEach((hazard) => this.spawnStaticTile(hazard, 'hazard', this.hazards));
+
+    const { exit } = LEVEL_DATA;
+    const exitSprite = this.physics.add.staticSprite(exit.x + exit.w / 2, exit.y + exit.h / 2, 'exit');
+    exitSprite.setDisplaySize(exit.w, exit.h).refreshBody();
+    this.exitZone = exitSprite as StaticSprite;
+  }
+
+  private setupPlayer(): void {
+    const startX = 120;
+    const startY = LEVEL_DATA.groundY - 140;
+
+    const player = this.physics.add.sprite(startX, startY, 'player');
+    player.setBounce(0);
+    player.setCollideWorldBounds(true);
+    player.setDepth(5);
+    player.setDragX(1200);
+    player.setMaxVelocity(RUNNER_CONSTANTS.moveSpeed, Math.abs(RUNNER_CONSTANTS.jumpVelocity) * 1.5);
+
+    const body = player.body as Phaser.Physics.Arcade.Body;
+    body.setSize(player.width * 0.6, player.height);
+    body.setOffset(player.width * 0.2, 0);
+
+    this.player = player as DynamicSprite;
+
+    this.physics.add.collider(this.player, this.platforms);
+    this.physics.add.overlap(this.player, this.hazards, () => this.restartLevel(), undefined, this);
+    this.physics.add.overlap(this.player, this.exitZone, () => this.completeLevel(), undefined, this);
+  }
+
+  private setupCamera(): void {
+    const camera = this.cameras.main;
+    const { width, height } = LEVEL_DATA.world;
+
+    camera.setBounds(0, 0, width, height);
+    camera.setBackgroundColor(0x0f172a);
+    camera.startFollow(this.player, true, 0.12, 0.12);
+    camera.setDeadzone(200, 120);
+    camera.setRoundPixels(true);
+  }
+
+  private setupHud(): void {
+    this.hudText = this.add
+      .text(16, 16, '', {
+        fontSize: '20px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.pauseOverlay = this.add
+      .text(this.scale.width / 2, this.scale.height / 2, 'PAUSE', {
+        fontSize: '48px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5)
+      .setScrollFactor(0)
+      .setDepth(200)
+      .setVisible(false);
+  }
+
+  private processMovement(time: number): void {
+    const body = this.player.body;
+    if (!body) {
+      return;
+    }
+
+    this.captureJumpBuffer(time);
+
+    const bodyCast = body as Phaser.Physics.Arcade.Body;
+    const moveLeft = (this.cursors.left?.isDown ?? false) || this.keyA.isDown;
+    const moveRight = (this.cursors.right?.isDown ?? false) || this.keyD.isDown;
+
+    if (moveLeft && !moveRight) {
+      bodyCast.setVelocityX(-RUNNER_CONSTANTS.moveSpeed);
+      this.player.setFlipX(true);
+    } else if (moveRight && !moveLeft) {
+      bodyCast.setVelocityX(RUNNER_CONSTANTS.moveSpeed);
+      this.player.setFlipX(false);
+    } else {
+      bodyCast.setVelocityX(0);
+    }
+
+    const onGround = bodyCast.blocked.down || bodyCast.touching.down;
+    if (onGround) {
+      this.lastGroundedAt = time;
+    }
+
+    const canCoyote = time - this.lastGroundedAt <= RUNNER_CONSTANTS.coyoteTimeMs;
+    const jumpBuffered = time - this.jumpBufferedAt <= RUNNER_CONSTANTS.jumpBufferMs;
+
+    if (jumpBuffered && (onGround || canCoyote)) {
+      bodyCast.setVelocityY(RUNNER_CONSTANTS.jumpVelocity);
+      this.jumpBufferedAt = Number.NEGATIVE_INFINITY;
+      this.lastGroundedAt = Number.NEGATIVE_INFINITY;
+    }
+  }
+
+  private captureJumpBuffer(time: number): void {
+    for (const key of this.jumpKeys) {
+      if (Phaser.Input.Keyboard.JustDown(key)) {
+        this.jumpBufferedAt = time;
+      }
+    }
+  }
+
+  private checkFailState(): void {
+    if (this.player.y > LEVEL_DATA.world.height + 200) {
+      this.restartLevel();
+    }
+  }
+
+  private restartLevel(): void {
+    this.scene.restart();
+  }
+
+  private completeLevel(): void {
+    const elapsed = this.getElapsedSeconds(this.time.now);
+    // eslint-disable-next-line no-console
+    console.info(`Level geschafft in ${elapsed.toFixed(2)}s`);
+    this.scene.restart();
+  }
+
+  private handlePauseToggle(time: number): void {
+    if (Phaser.Input.Keyboard.JustDown(this.pauseKey)) {
+      this.isPaused = !this.isPaused;
+
+      if (this.isPaused) {
+        this.pauseStartedAt = time;
+        this.physics.world.pause();
+      } else {
+        this.accumulatedPauseTime += time - this.pauseStartedAt;
+        this.physics.world.resume();
+      }
+
+      this.pauseOverlay.setVisible(this.isPaused);
+    }
+  }
+
+  private updateHud(time: number): void {
+    const elapsed = this.getElapsedSeconds(time);
+    this.hudText.setText(`Level: ${LEVEL_DATA.name}\nTime: ${elapsed.toFixed(2)}s`);
+  }
+
+  private getElapsedSeconds(time: number): number {
+    if (this.isPaused) {
+      const pauseEffectiveStart = this.pauseStartedAt || time;
+      return (pauseEffectiveStart - this.levelStartTime - this.accumulatedPauseTime) / 1000;
+    }
+
+    return (time - this.levelStartTime - this.accumulatedPauseTime) / 1000;
+  }
+
+  private spawnStaticTile(
+    spec: RectangleSpec,
+    texture: string,
+    group: Phaser.Physics.Arcade.StaticGroup,
+  ): void {
+    const sprite = group.create(spec.x + spec.w / 2, spec.y + spec.h / 2, texture) as StaticSprite;
+    sprite.setDisplaySize(spec.w, spec.h);
+    sprite.refreshBody();
+  }
+}

--- a/apps/web/src/types/game.ts
+++ b/apps/web/src/types/game.ts
@@ -1,0 +1,34 @@
+export interface RectangleSpec {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface LevelDefinition {
+  name: string;
+  world: {
+    width: number;
+    height: number;
+  };
+  groundY: number;
+  platforms: RectangleSpec[];
+  hazards: RectangleSpec[];
+  exit: RectangleSpec;
+}
+
+export interface RunnerConstants {
+  gravityY: number;
+  moveSpeed: number;
+  jumpVelocity: number;
+  coyoteTimeMs: number;
+  jumpBufferMs: number;
+}
+
+export const RUNNER_CONSTANTS: RunnerConstants = {
+  gravityY: 1200,
+  moveSpeed: 180,
+  jumpVelocity: -520,
+  coyoteTimeMs: 90,
+  jumpBufferMs: 100,
+};


### PR DESCRIPTION
## Summary
- bootstrap Phaser scenes and textures for a placeholder arcade runner
- implement Demo-01 level with responsive movement, hazards, exit, HUD, and pause logic
- document web controls and goal in the README

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68dd46281d90832db08613928eb7dda6