### PR TITLE
feat(api): sqlite store and job queues (stub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ pnpm dev
 - Web-App erreichbar unter [http://localhost:5173](http://localhost:5173)
 - API erreichbar unter [http://localhost:3000](http://localhost:3000)
 
-### API: `/levels/demo`
-- `GET http://localhost:3000/levels/demo`
-  - Liefert ein Demo-Level nach dem gemeinsamen Zod-Schema aus `@ir/game-spec`.
-  - Bei Validierungsfehlern sendet die API einen `500`-Status mit Fehlerinformationen.
+### API-Workflows
+- `GET http://localhost:3000/health` prüft DB- und Redis-Verfügbarkeit.
+- `POST http://localhost:3000/levels/generate` erstellt einen Generierungsjob (stub) und stößt automatisch einen Testjob an.
+- `GET http://localhost:3000/jobs/<jobId>` zeigt den Jobfortschritt (`queued` → `running` → `succeeded`).
+- `GET http://localhost:3000/levels?published=false&limit=5` listet unveröffentlichte Level.
+- `POST http://localhost:3000/levels/<levelId>/publish` setzt das Veröffentlichungsflag.
+
+Alle Level-Daten validieren gegen `@ir/game-spec`, persistieren in SQLite (`./apps/api/data/app.db`) und werden über BullMQ/Redis im Stub-Workflow verarbeitet.
 
 ### Web starten
 
@@ -32,7 +36,7 @@ pnpm --filter web dev
 docker compose up --build
 ```
 - Nutzt lokale Dockerfiles der Pakete
-- Startet Web, API, Playtester-Service sowie Redis
+- Startet Web, API, Playtester-Service sowie Redis. Die API speichert ihren Zustand in einem Docker-Volume (`api-data`).
 
 ## Repository-Struktur
 ```
@@ -55,3 +59,4 @@ docker compose up --build
 ## Umgebung
 - `OPENAI_API_KEY` – Platzhalter für künftige KI-Integration
 - `REDIS_URL=redis://redis:6379` – Verbindung zur Redis-Instanz aus Docker Compose
+- `DB_PATH=./data/app.db` – Speicherort der SQLite-Datenbank (Standard)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:20-alpine
-WORKDIR /app
+WORKDIR /usr/src/app
 ENV NODE_ENV=development
+RUN apk add --no-cache python3 make g++
 RUN corepack enable
 COPY package.json ./
 COPY tsconfig.json ./
 COPY src ./src
 RUN pnpm install
+RUN mkdir -p data
+VOLUME ["/usr/src/app/data"]
 EXPOSE 3000
 CMD ["pnpm", "dev"]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,92 @@
+# API Service
+
+Der API-Dienst stellt einen stabilen Kern für das Infinite-Runner-SaaS bereit. Er verwaltet Level-Persistenz per SQLite sowie Stub-Queues für Generierungs- und Test-Jobs über Redis/BullMQ.
+
+## Voraussetzungen
+- Node.js LTS (>= 20)
+- pnpm (>= 8)
+- Redis-Instanz (z.B. via `docker compose`)
+
+## Konfiguration
+| Variable   | Standardwert             | Beschreibung |
+|------------|--------------------------|--------------|
+| `PORT`     | `3000`                   | HTTP-Port der API |
+| `DB_PATH`  | `./data/app.db`          | Pfad zur SQLite-Datenbank |
+| `REDIS_URL`| `redis://redis:6379`     | Verbindung zur Redis-Instanz |
+
+## Wichtige Skripte
+```bash
+pnpm install          # Dependencies installieren
+pnpm --filter api migrate   # Tabellen erzeugen (idempotent)
+pnpm --filter api dev       # Entwicklung mit Nodemon + Fastify
+pnpm --filter api build     # TypeScript-Build nach dist/
+pnpm --filter api start     # Produktionsstart (nutzt dist/app.js)
+```
+
+## Endpunkte
+Alle Level-Strukturen werden mit `@ir/game-spec` validiert, bevor sie ausgeliefert oder persistiert werden.
+
+### `GET /health`
+Antwortet mit dem Zustand von DB und Redis.
+```bash
+curl http://localhost:3000/health
+# {"status":"ok","db":true,"redis":true}
+```
+
+### `GET /levels/:id`
+Liefert ein einzelnes Level.
+```bash
+curl http://localhost:3000/levels/<levelId>
+```
+
+### `GET /levels`
+Listet Level mit optionaler Filterung und Pagination.
+```bash
+curl "http://localhost:3000/levels?published=false&limit=5"
+```
+Antwort:
+```json
+{
+  "levels": [
+    {
+      "level": { "id": "...", "seed": "...", ... },
+      "published": false,
+      "createdAt": 1700000000000,
+      "updatedAt": 1700000000000
+    }
+  ]
+}
+```
+
+### `POST /levels/:id/publish`
+Setzt das Veröffentlichungs-Flag.
+```bash
+curl -X POST \
+  http://localhost:3000/levels/<levelId>/publish \
+  -H "content-type: application/json" \
+  -d '{"published":true}'
+```
+
+### `POST /levels/generate`
+Erzeugt einen Generierungsauftrag. Optional können `seed`, `difficulty` sowie `abilities` gesetzt werden.
+```bash
+curl -X POST http://localhost:3000/levels/generate \
+  -H "content-type: application/json" \
+  -d '{"seed":"s1","difficulty":1,"abilities":{"run":true,"jump":true}}'
+# {"jobId":"<uuid>"}
+```
+
+### `GET /jobs/:id`
+Abfrage des Jobstatus. Der Generierungs-Job erzeugt im Erfolgsfall automatisch einen nachgelagerten Test-Job.
+```bash
+curl http://localhost:3000/jobs/<jobId>
+# {"id":"...","type":"gen","status":"running"}
+```
+
+Sobald sowohl Generierungs- als auch Test-Job abgeschlossen sind, ist das Level in der Datenbank verfügbar und kann veröffentlicht werden.
+
+## Shutdown
+Der Dienst behandelt `SIGINT`/`SIGTERM`, wartet auf das Beenden der Worker und schließt die SQLite-Verbindung sauber.
+
+## Docker-Hinweise
+Der Container legt seine Daten unter `/usr/src/app/data` ab. Über Docker Compose wird dieses Verzeichnis als Named Volume (`api-data`) gemountet.

--- a/apps/api/data/.gitignore
+++ b/apps/api/data/.gitignore
@@ -1,0 +1,3 @@
+# SQLite database files
+*
+!.gitignore

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,19 +4,29 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/server.ts",
+    "dev": "nodemon --watch src --ext ts --exec \"tsx src/app.ts\"",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/server.js",
+    "start": "node dist/app.js",
+    "migrate": "tsx src/migrate.ts",
     "lint": "eslint \"src/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\""
   },
   "dependencies": {
     "@fastify/cors": "^8.4.2",
     "@ir/game-spec": "workspace:^",
-    "fastify": "^4.25.2"
+    "better-sqlite3": "^9.4.0",
+    "bullmq": "^5.12.0",
+    "fastify": "^4.25.2",
+    "ioredis": "^5.3.2",
+    "pino": "^9.4.0",
+    "uuid": "^9.0.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/uuid": "^9.0.7",
+    "nodemon": "^3.0.3",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3"
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,51 @@
+import { createServer } from './server';
+import { closeDb, initDb, migrate } from './db';
+import { createQueueManager } from './queue';
+
+async function bootstrap() {
+  initDb();
+  migrate();
+  const queueManager = await createQueueManager();
+  const server = createServer({ queueManager });
+
+  const port = Number(process.env.PORT ?? 3000);
+  await server.listen({ port, host: '0.0.0.0' });
+  server.log.info(`API listening on http://localhost:${port}`);
+
+  let shuttingDown = false;
+  async function shutdown(signal: NodeJS.Signals) {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    server.log.info({ signal }, 'Received shutdown signal');
+    try {
+      await server.close();
+      await queueManager.close();
+    } catch (error) {
+      server.log.error({ err: error }, 'Error while closing resources');
+    } finally {
+      closeDb();
+      process.exit(0);
+    }
+  }
+
+  const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+  for (const signal of signals) {
+    process.once(signal, () => {
+      shutdown(signal).catch((error) => {
+        server.log.error({ err: error }, 'Error during shutdown');
+        process.exit(1);
+      });
+    });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  bootstrap().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export { bootstrap };

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,0 +1,277 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { Level, LevelT } from '@ir/game-spec';
+
+export type JobType = 'gen' | 'test';
+export type JobStatus = 'queued' | 'running' | 'failed' | 'succeeded';
+
+export interface JobRecord {
+  id: string;
+  type: JobType;
+  status: JobStatus;
+  levelId: string | null;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface LevelRecord {
+  level: LevelT;
+  published: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface LevelRow {
+  id: string;
+  seed: string;
+  rules_json: string;
+  tiles_json: string;
+  moving_json: string;
+  items_json: string;
+  enemies_json: string;
+  checkpoints_json: string;
+  exit_json: string;
+  difficulty: number;
+  published: number;
+  created_at: number;
+  updated_at: number;
+}
+
+interface JobRow {
+  id: string;
+  type: string;
+  status: string;
+  level_id: string | null;
+  error: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+let dbInstance: Database.Database | null = null;
+
+const DEFAULT_DB_PATH = './data/app.db';
+
+function resolveDbPath(dbPath: string): string {
+  return path.isAbsolute(dbPath) ? dbPath : path.resolve(process.cwd(), dbPath);
+}
+
+function ensureDirectoryFor(filePath: string) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function initDb(dbPath = process.env.DB_PATH ?? DEFAULT_DB_PATH): Database.Database {
+  const resolvedPath = resolveDbPath(dbPath);
+  ensureDirectoryFor(resolvedPath);
+
+  if (dbInstance) {
+    return dbInstance;
+  }
+
+  dbInstance = new Database(resolvedPath);
+  dbInstance.pragma('journal_mode = WAL');
+  return dbInstance;
+}
+
+export function getDb(): Database.Database {
+  if (!dbInstance) {
+    throw new Error('Database not initialised. Call initDb() first.');
+  }
+  return dbInstance;
+}
+
+export function closeDb() {
+  if (dbInstance) {
+    dbInstance.close();
+    dbInstance = null;
+  }
+}
+
+export function migrate() {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS levels (
+      id TEXT PRIMARY KEY,
+      seed TEXT NOT NULL,
+      rules_json TEXT NOT NULL,
+      tiles_json TEXT NOT NULL,
+      moving_json TEXT NOT NULL,
+      items_json TEXT NOT NULL,
+      enemies_json TEXT NOT NULL,
+      checkpoints_json TEXT NOT NULL,
+      exit_json TEXT NOT NULL,
+      difficulty INTEGER NOT NULL,
+      published INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS jobs (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      level_id TEXT,
+      error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(level_id) REFERENCES levels(id)
+    );
+  `);
+
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_levels_published ON levels(published);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);`);
+}
+
+function rowToLevel(row: LevelRow): LevelT {
+  const level: LevelT = {
+    id: row.id,
+    seed: row.seed,
+    rules: JSON.parse(row.rules_json),
+    tiles: JSON.parse(row.tiles_json),
+    moving: JSON.parse(row.moving_json),
+    items: JSON.parse(row.items_json),
+    enemies: JSON.parse(row.enemies_json),
+    checkpoints: JSON.parse(row.checkpoints_json),
+    exit: JSON.parse(row.exit_json),
+  };
+
+  return Level.parse(level);
+}
+
+export function insertLevel(level: LevelT, meta: { difficulty: number; seed: string }) {
+  const db = getDb();
+  const now = Date.now();
+
+  const stmt = db.prepare(`
+    INSERT INTO levels (
+      id, seed, rules_json, tiles_json, moving_json, items_json,
+      enemies_json, checkpoints_json, exit_json, difficulty, published, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+  `);
+
+  stmt.run(
+    level.id,
+    meta.seed,
+    JSON.stringify(level.rules),
+    JSON.stringify(level.tiles),
+    JSON.stringify(level.moving ?? []),
+    JSON.stringify(level.items ?? []),
+    JSON.stringify(level.enemies ?? []),
+    JSON.stringify(level.checkpoints ?? []),
+    JSON.stringify(level.exit),
+    meta.difficulty,
+    now,
+    now,
+  );
+}
+
+export function getLevel(id: string): LevelT | null {
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM levels WHERE id = ?').get(id) as LevelRow | undefined;
+  if (!row) {
+    return null;
+  }
+
+  return rowToLevel(row);
+}
+
+export function listLevels(params: { published?: boolean; limit?: number; offset?: number }): LevelRecord[] {
+  const db = getDb();
+  const conditions: string[] = [];
+  const values: any[] = [];
+
+  if (typeof params.published === 'boolean') {
+    conditions.push('published = ?');
+    values.push(params.published ? 1 : 0);
+  }
+
+  let query = 'SELECT * FROM levels';
+  if (conditions.length > 0) {
+    query += ` WHERE ${conditions.join(' AND ')}`;
+  }
+  query += ' ORDER BY created_at DESC';
+
+  if (typeof params.limit === 'number') {
+    query += ' LIMIT ?';
+    values.push(params.limit);
+  }
+
+  if (typeof params.offset === 'number') {
+    query += ' OFFSET ?';
+    values.push(params.offset);
+  }
+
+  const rows = db.prepare(query).all(...values) as LevelRow[];
+
+  return rows.map((row) => ({
+    level: rowToLevel(row),
+    published: Boolean(row.published),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}
+
+export function setPublished(id: string, published: boolean): boolean {
+  const db = getDb();
+  const stmt = db.prepare('UPDATE levels SET published = ?, updated_at = ? WHERE id = ?');
+  const result = stmt.run(published ? 1 : 0, Date.now(), id);
+  return result.changes > 0;
+}
+
+export function insertJob(job: { id: string; type: JobType; status: JobStatus; level_id?: string | null }) {
+  const db = getDb();
+  const now = Date.now();
+  const stmt = db.prepare(`
+    INSERT INTO jobs (id, type, status, level_id, error, created_at, updated_at)
+    VALUES (?, ?, ?, ?, NULL, ?, ?)
+  `);
+  stmt.run(job.id, job.type, job.status, job.level_id ?? null, now, now);
+}
+
+export function updateJobStatus(id: string, status: JobStatus, options: { error?: string; levelId?: string } = {}) {
+  const db = getDb();
+  const stmt = db.prepare(`
+    UPDATE jobs
+    SET status = ?,
+        error = ?,
+        level_id = COALESCE(?, level_id),
+        updated_at = ?
+    WHERE id = ?
+  `);
+  stmt.run(status, options.error ?? null, options.levelId ?? null, Date.now(), id);
+}
+
+export function getJob(id: string): JobRecord | null {
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM jobs WHERE id = ?').get(id) as JobRow | undefined;
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    type: row.type as JobType,
+    status: row.status as JobStatus,
+    levelId: row.level_id ?? null,
+    error: row.error ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function isDbHealthy(): boolean {
+  try {
+    const db = getDb();
+    db.prepare('SELECT 1').get();
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/apps/api/src/demo.ts
+++ b/apps/api/src/demo.ts
@@ -1,0 +1,39 @@
+import { Ability, LevelT } from '@ir/game-spec';
+import { z } from 'zod';
+
+const BASE_TILES = [
+  { x: 0, y: 620, w: 1200, h: 40, type: 'ground' as const },
+  { x: 1350, y: 560, w: 220, h: 24, type: 'platform' as const },
+  { x: 1700, y: 520, w: 220, h: 24, type: 'platform' as const },
+  { x: 2050, y: 480, w: 220, h: 24, type: 'platform' as const },
+  { x: 2500, y: 620, w: 800, h: 40, type: 'ground' as const },
+  { x: 3450, y: 560, w: 220, h: 24, type: 'platform' as const },
+  { x: 1200, y: 600, w: 120, h: 20, type: 'hazard' as const },
+  { x: 3300, y: 600, w: 120, h: 20, type: 'hazard' as const },
+];
+
+type AbilityInput = z.input<typeof Ability>;
+
+export function demoLevel(
+  difficulty: number,
+  seed: string,
+  abilities: AbilityInput = { run: true, jump: true },
+): LevelT {
+  const parsedAbilities = Ability.parse(abilities);
+
+  return {
+    id: 'demo-template',
+    seed,
+    rules: {
+      abilities: parsedAbilities,
+      duration_target_s: 60,
+      difficulty,
+    },
+    tiles: BASE_TILES,
+    moving: [],
+    items: [],
+    enemies: [],
+    checkpoints: [],
+    exit: { x: 3800, y: 560 },
+  };
+}

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -1,0 +1,12 @@
+import { closeDb, initDb, migrate } from './db';
+
+async function run() {
+  initDb();
+  migrate();
+  closeDb();
+}
+
+run().catch((error) => {
+  console.error('Migration failed:', error);
+  process.exit(1);
+});

--- a/apps/api/src/queue/index.ts
+++ b/apps/api/src/queue/index.ts
@@ -1,0 +1,170 @@
+import { Queue, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+import { setTimeout as delay } from 'node:timers/promises';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Ability, Level } from '@ir/game-spec';
+import { z } from 'zod';
+
+import { demoLevel } from '../demo';
+import { insertJob, insertLevel, updateJobStatus } from '../db';
+
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+
+type AbilityInput = z.input<typeof Ability>;
+
+export interface GenJobData {
+  seed?: string;
+  difficulty?: number;
+  abilities?: AbilityInput;
+}
+
+export interface TestJobData {
+  levelId: string;
+}
+
+export interface QueueManager {
+  enqueueGen(input: GenJobData): Promise<string>;
+  isHealthy(): Promise<boolean>;
+  close(): Promise<void>;
+}
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export async function createQueueManager(): Promise<QueueManager> {
+  const connection = new IORedis(REDIS_URL);
+
+  const genQueue = new Queue<GenJobData>('gen', {
+    connection,
+    defaultJobOptions: {
+      removeOnComplete: true,
+    },
+  });
+  const testQueue = new Queue<TestJobData>('test', {
+    connection,
+    defaultJobOptions: {
+      removeOnComplete: true,
+    },
+  });
+
+  const genWorker = new Worker<GenJobData>(
+    'gen',
+    async (job) => {
+      try {
+        const jobId = job.id;
+        if (!jobId) {
+          throw new Error('Missing job id for generation job');
+        }
+        await updateJobStatus(jobId, 'running');
+
+        const seed = job.data?.seed ?? uuidv4();
+        const difficulty = job.data?.difficulty ?? 1;
+        const abilitiesInput = job.data?.abilities ?? { run: true, jump: true };
+        const abilities = Ability.parse(abilitiesInput);
+
+        const baseLevel = demoLevel(difficulty, seed, abilities);
+        const levelId = uuidv4();
+        const level = Level.parse({
+          ...baseLevel,
+          id: levelId,
+          seed,
+          rules: {
+            ...baseLevel.rules,
+            difficulty,
+            abilities,
+          },
+        });
+
+        insertLevel(level, { difficulty: level.rules.difficulty, seed: level.seed });
+
+        const testJobId = uuidv4();
+        await insertJob({ id: testJobId, type: 'test', status: 'queued', level_id: levelId });
+        try {
+          await testQueue.add('test-level', { levelId }, { jobId: testJobId });
+        } catch (error) {
+          const message = resolveErrorMessage(error);
+          await updateJobStatus(testJobId, 'failed', { error: message });
+          throw error;
+        }
+
+        await updateJobStatus(jobId, 'succeeded', { levelId });
+        return { levelId, testJobId };
+      } catch (error) {
+        const message = resolveErrorMessage(error);
+        const jobId = job.id;
+        if (jobId) {
+          await updateJobStatus(jobId, 'failed', { error: message });
+        }
+        throw error;
+      }
+    },
+    { connection },
+  );
+
+  const testWorker = new Worker<TestJobData>(
+    'test',
+    async (job) => {
+      try {
+        const jobId = job.id;
+        if (!jobId) {
+          throw new Error('Missing job id for test job');
+        }
+        await updateJobStatus(jobId, 'running');
+        await delay(500);
+        await updateJobStatus(jobId, 'succeeded');
+        return { levelId: job.data.levelId };
+      } catch (error) {
+        const message = resolveErrorMessage(error);
+        const jobId = job.id;
+        if (jobId) {
+          await updateJobStatus(jobId, 'failed', { error: message });
+        }
+        throw error;
+      }
+    },
+    { connection },
+  );
+
+  async function enqueueGen(input: GenJobData): Promise<string> {
+    const jobId = uuidv4();
+    await insertJob({ id: jobId, type: 'gen', status: 'queued' });
+    try {
+      await genQueue.add('generate-level', input, { jobId });
+    } catch (error) {
+      const message = resolveErrorMessage(error);
+      await updateJobStatus(jobId, 'failed', { error: message });
+      throw error;
+    }
+    return jobId;
+  }
+
+  async function isHealthyRedis(): Promise<boolean> {
+    try {
+      await connection.ping();
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async function close() {
+    await Promise.allSettled([genWorker.close(), testWorker.close()]);
+    await Promise.allSettled([genQueue.close(), testQueue.close()]);
+    try {
+      await connection.quit();
+    } catch (error) {
+      connection.disconnect();
+    }
+  }
+
+  return {
+    enqueueGen,
+    isHealthy: isHealthyRedis,
+    close,
+  };
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,74 +1,134 @@
 import cors from '@fastify/cors';
 import Fastify from 'fastify';
+import pino from 'pino';
+import { ZodError, z } from 'zod';
 
-import { Level, LevelT } from '@ir/game-spec';
+import { Ability, Level } from '@ir/game-spec';
 
-const server = Fastify({
-  logger: true,
+import { getJob, getLevel, isDbHealthy, listLevels, setPublished } from './db';
+import type { QueueManager } from './queue';
+
+const PublishBodySchema = z.object({
+  published: z.boolean(),
 });
 
-server.register(cors, {
-  origin: 'http://localhost:5173',
+const GenerateBodySchema = z
+  .object({
+    seed: z.string().optional(),
+    difficulty: z.coerce.number().int().min(1).optional(),
+    abilities: Ability.optional(),
+  })
+  .optional();
+
+const ListQuerySchema = z.object({
+  published: z.enum(['true', 'false']).optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
 });
 
-const DEMO_LEVEL: LevelT = {
-  id: 'demo-01',
-  seed: 'demo',
-  rules: {
-    abilities: {
-      run: true,
-      jump: true,
-    },
-    duration_target_s: 60,
-    difficulty: 1,
-  },
-  tiles: [
-    { x: 0, y: 620, w: 1200, h: 40, type: 'ground' },
-    { x: 1350, y: 560, w: 220, h: 24, type: 'platform' },
-    { x: 1700, y: 520, w: 220, h: 24, type: 'platform' },
-    { x: 2050, y: 480, w: 220, h: 24, type: 'platform' },
-    { x: 2500, y: 620, w: 800, h: 40, type: 'ground' },
-    { x: 3450, y: 560, w: 220, h: 24, type: 'platform' },
-    { x: 1200, y: 600, w: 120, h: 20, type: 'hazard' },
-    { x: 3300, y: 600, w: 120, h: 20, type: 'hazard' },
-  ],
-  moving: [],
-  items: [],
-  enemies: [],
-  checkpoints: [],
-  exit: { x: 3800, y: 560 },
-};
+export interface ServerDependencies {
+  queueManager: QueueManager;
+}
 
-server.get('/health', async () => ({ status: 'ok' }));
+export function createServer({ queueManager }: ServerDependencies) {
+  const server = Fastify({
+    logger: pino({ level: process.env.LOG_LEVEL ?? 'info' }),
+  });
 
-server.get('/levels/demo', async (_, reply) => {
-  const result = Level.safeParse(DEMO_LEVEL);
+  server.register(cors, {
+    origin: 'http://localhost:5173',
+  });
 
-  if (!result.success) {
-    server.log.error({ err: result.error }, 'Invalid demo level schema');
-    return reply.status(500).send({
-      error: 'Invalid level schema',
-      detail: result.error.flatten(),
+  server.setErrorHandler((error, request, reply) => {
+    if (error instanceof ZodError) {
+      request.log.warn({ err: error }, 'Validation error');
+      return reply.status(400).send({
+        message: 'Validation error',
+        issues: error.flatten(),
+      });
+    }
+
+    request.log.error({ err: error }, 'Unhandled error');
+    const statusCode = 'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : 500;
+    reply.status(statusCode).send({ message: error.message ?? 'Internal Server Error' });
+  });
+
+  server.get('/health', async () => {
+    const redisHealthy = await queueManager.isHealthy();
+    return {
+      status: 'ok',
+      db: isDbHealthy(),
+      redis: redisHealthy,
+    };
+  });
+
+  server.get('/levels/:id', async (request, reply) => {
+    const params = z.object({ id: z.string() }).parse(request.params);
+    const level = getLevel(params.id);
+    if (!level) {
+      return reply.status(404).send({ message: 'Level not found' });
+    }
+
+    return Level.parse(level);
+  });
+
+  server.get('/levels', async (request) => {
+    const query = ListQuerySchema.parse(request.query);
+    const levels = listLevels({
+      published: typeof query.published === 'string' ? query.published === 'true' : undefined,
+      limit: query.limit,
+      offset: query.offset,
     });
-  }
 
-  return result.data;
-});
+    return {
+      levels: levels.map((entry) => ({
+        level: Level.parse(entry.level),
+        published: entry.published,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      })),
+    };
+  });
 
-const port = Number(process.env.PORT) || 3000;
+  server.post('/levels/:id/publish', async (request, reply) => {
+    const params = z.object({ id: z.string() }).parse(request.params);
+    const body = PublishBodySchema.parse(request.body);
 
-async function start() {
-  try {
-    await server.listen({ port, host: '0.0.0.0' });
-    console.log(`API listening on http://localhost:${port}`);
-  } catch (err) {
-    server.log.error(err);
-    process.exit(1);
-  }
+    const updated = setPublished(params.id, body.published);
+    if (!updated) {
+      return reply.status(404).send({ message: 'Level not found' });
+    }
+
+    return { id: params.id, published: body.published };
+  });
+
+  server.post('/levels/generate', async (request) => {
+    const body = GenerateBodySchema.parse(request.body) ?? {};
+    const jobId = await queueManager.enqueueGen({
+      seed: body.seed,
+      difficulty: body.difficulty,
+      abilities: body.abilities,
+    });
+    return { jobId };
+  });
+
+  server.get('/jobs/:id', async (request, reply) => {
+    const params = z.object({ id: z.string() }).parse(request.params);
+    const job = getJob(params.id);
+    if (!job) {
+      return reply.status(404).send({ message: 'Job not found' });
+    }
+
+    return {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      level_id: job.levelId ?? undefined,
+      error: job.error ?? undefined,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+    };
+  });
+
+  return server;
 }
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  start();
-}
-
-export default server;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       REDIS_URL: redis://redis:6379
     depends_on:
       - redis
+    volumes:
+      - api-data:/usr/src/app/data
 
   playtester:
     build:
@@ -43,3 +45,6 @@ services:
     image: redis:7-alpine
     ports:
       - '6379:6379'
+
+volumes:
+  api-data:

--- a/package.json
+++ b/package.json
@@ -23,5 +23,17 @@
     "prettier": "^3.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.8.0"
-  }
+  },
+  "pnpm": {
+    "allowedBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "msgpackr-extract"
+    ]
+  },
+  "trustedDependencies": [
+    "better-sqlite3",
+    "esbuild",
+    "msgpackr-extract"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a SQLite-backed repository with migrations and helpers for levels and job records
- wire BullMQ queues, demo level stubs, and Fastify routes for health, level management, and job status
- introduce an application bootstrap, updated scripts, and Docker volume configuration for persistent data

## Testing
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68dd4d6a4aa8832d88c62424c07ec63d