### PR TITLE
Add OpenAI-powered playtester workers and internal ingest APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,30 @@ pnpm dev
 ```
 - Web-App erreichbar unter [http://localhost:5173](http://localhost:5173)
 - API erreichbar unter [http://localhost:3000](http://localhost:3000)
+- KI-Playtester-Worker: `pnpm playtester`
 
 ### API-Workflows
 - `GET http://localhost:3000/health` prüft DB- und Redis-Verfügbarkeit.
-- `POST http://localhost:3000/levels/generate` erstellt einen Generierungsjob (stub) und stößt automatisch einen Testjob an.
+- `POST http://localhost:3000/levels/generate` erstellt einen Generierungsjob; die Ausführung übernimmt der Playtester-Service (gen → test).
 - `GET http://localhost:3000/jobs/<jobId>` zeigt den Jobfortschritt (`queued` → `running` → `succeeded`).
 - `GET http://localhost:3000/levels?published=false&limit=5` listet unveröffentlichte Level.
 - `POST http://localhost:3000/levels/<levelId>/publish` setzt das Veröffentlichungsflag.
 
-Alle Level-Daten validieren gegen `@ir/game-spec`, persistieren in SQLite (`./apps/api/data/app.db`) und werden über BullMQ/Redis im Stub-Workflow verarbeitet.
+Alle Level-Daten validieren gegen `@ir/game-spec`, persistieren in SQLite (`./apps/api/data/app.db`) und werden über BullMQ/Redis verarbeitet.
+
+### Playtester Service
+- Start: `pnpm playtester` (lokal) oder via Docker Compose.
+- Benötigte Umgebungsvariablen:
+  - `OPENAI_API_KEY` (Pflicht)
+  - `OPENAI_MODEL` (Standard: `gpt-4.1-mini`)
+  - `OPENAI_REQ_TIMEOUT_MS` (Standard: `20000`)
+  - `GEN_MAX_ATTEMPTS` (Standard: `3`)
+  - `GEN_SIMHASH_TTL_SEC` (Standard: `604800`)
+  - `REDIS_URL` (Standard: `redis://redis:6379`)
+  - `API_BASE_URL` (Standard: `http://localhost:3000`)
+  - `INTERNAL_TOKEN` (muss mit der API übereinstimmen, Standard `dev-internal`)
+- Queues: `gen` (Concurrency 2) & `test` (Concurrency 4) via BullMQ.
+- Der Worker schreibt Levels und Job-Status über interne API-Endpunkte (`/internal/*`) zurück.
 
 ### Web starten
 
@@ -57,6 +72,11 @@ docker compose up --build
 - `pnpm format` – führt Prettier im Check-Modus in allen Workspaces aus
 
 ## Umgebung
-- `OPENAI_API_KEY` – Platzhalter für künftige KI-Integration
+- `OPENAI_API_KEY` – API-Schlüssel für OpenAI-basierte Generierung
+- `OPENAI_MODEL=gpt-4.1-mini` – Vorgabemodell für den Generator
+- `OPENAI_REQ_TIMEOUT_MS=20000` – Timeout für OpenAI-Anfragen (ms)
+- `GEN_MAX_ATTEMPTS=3` – Maximale Generierungsversuche
+- `GEN_SIMHASH_TTL_SEC=604800` – TTL für Layout-Signaturen (Sekunden)
 - `REDIS_URL=redis://redis:6379` – Verbindung zur Redis-Instanz aus Docker Compose
 - `DB_PATH=./data/app.db` – Speicherort der SQLite-Datenbank (Standard)
+- `INTERNAL_TOKEN=dev-internal` – Shared Secret für interne API-Aufrufe (Playtester ↔ API)

--- a/apps/api/src/queue/index.ts
+++ b/apps/api/src/queue/index.ts
@@ -1,13 +1,11 @@
-import { Queue, Worker } from 'bullmq';
+import { Queue } from 'bullmq';
 import IORedis from 'ioredis';
-import { setTimeout as delay } from 'node:timers/promises';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Ability, Level } from '@ir/game-spec';
+import { Ability } from '@ir/game-spec';
 import { z } from 'zod';
 
-import { demoLevel } from '../demo';
-import { insertJob, insertLevel, updateJobStatus } from '../db';
+import { insertJob, updateJobStatus } from '../db';
 
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
 
@@ -17,10 +15,6 @@ export interface GenJobData {
   seed?: string;
   difficulty?: number;
   abilities?: AbilityInput;
-}
-
-export interface TestJobData {
-  levelId: string;
 }
 
 export interface QueueManager {
@@ -45,90 +39,6 @@ export async function createQueueManager(): Promise<QueueManager> {
       removeOnComplete: true,
     },
   });
-  const testQueue = new Queue<TestJobData>('test', {
-    connection,
-    defaultJobOptions: {
-      removeOnComplete: true,
-    },
-  });
-
-  const genWorker = new Worker<GenJobData>(
-    'gen',
-    async (job) => {
-      try {
-        const jobId = job.id;
-        if (!jobId) {
-          throw new Error('Missing job id for generation job');
-        }
-        await updateJobStatus(jobId, 'running');
-
-        const seed = job.data?.seed ?? uuidv4();
-        const difficulty = job.data?.difficulty ?? 1;
-        const abilitiesInput = job.data?.abilities ?? { run: true, jump: true };
-        const abilities = Ability.parse(abilitiesInput);
-
-        const baseLevel = demoLevel(difficulty, seed, abilities);
-        const levelId = uuidv4();
-        const level = Level.parse({
-          ...baseLevel,
-          id: levelId,
-          seed,
-          rules: {
-            ...baseLevel.rules,
-            difficulty,
-            abilities,
-          },
-        });
-
-        insertLevel(level, { difficulty: level.rules.difficulty, seed: level.seed });
-
-        const testJobId = uuidv4();
-        await insertJob({ id: testJobId, type: 'test', status: 'queued', level_id: levelId });
-        try {
-          await testQueue.add('test-level', { levelId }, { jobId: testJobId });
-        } catch (error) {
-          const message = resolveErrorMessage(error);
-          await updateJobStatus(testJobId, 'failed', { error: message });
-          throw error;
-        }
-
-        await updateJobStatus(jobId, 'succeeded', { levelId });
-        return { levelId, testJobId };
-      } catch (error) {
-        const message = resolveErrorMessage(error);
-        const jobId = job.id;
-        if (jobId) {
-          await updateJobStatus(jobId, 'failed', { error: message });
-        }
-        throw error;
-      }
-    },
-    { connection },
-  );
-
-  const testWorker = new Worker<TestJobData>(
-    'test',
-    async (job) => {
-      try {
-        const jobId = job.id;
-        if (!jobId) {
-          throw new Error('Missing job id for test job');
-        }
-        await updateJobStatus(jobId, 'running');
-        await delay(500);
-        await updateJobStatus(jobId, 'succeeded');
-        return { levelId: job.data.levelId };
-      } catch (error) {
-        const message = resolveErrorMessage(error);
-        const jobId = job.id;
-        if (jobId) {
-          await updateJobStatus(jobId, 'failed', { error: message });
-        }
-        throw error;
-      }
-    },
-    { connection },
-  );
 
   async function enqueueGen(input: GenJobData): Promise<string> {
     const jobId = uuidv4();
@@ -153,8 +63,7 @@ export async function createQueueManager(): Promise<QueueManager> {
   }
 
   async function close() {
-    await Promise.allSettled([genWorker.close(), testWorker.close()]);
-    await Promise.allSettled([genQueue.close(), testQueue.close()]);
+    await Promise.allSettled([genQueue.close()]);
     try {
       await connection.quit();
     } catch (error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       REDIS_URL: redis://redis:6379
+      INTERNAL_TOKEN: ${INTERNAL_TOKEN:-dev-internal}
     depends_on:
       - redis
     volumes:
@@ -38,6 +39,12 @@ services:
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       REDIS_URL: redis://redis:6379
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4.1-mini}
+      GEN_MAX_ATTEMPTS: ${GEN_MAX_ATTEMPTS:-3}
+      GEN_SIMHASH_TTL_SEC: ${GEN_SIMHASH_TTL_SEC:-604800}
+      OPENAI_REQ_TIMEOUT_MS: ${OPENAI_REQ_TIMEOUT_MS:-20000}
+      API_BASE_URL: http://api:3000
+      INTERNAL_TOKEN: ${INTERNAL_TOKEN:-dev-internal}
     depends_on:
       - redis
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"pnpm --filter web dev\" \"pnpm --filter api dev\"",
+    "playtester": "pnpm --filter @srv/playtester dev",
     "build": "pnpm -r run build",
     "lint": "pnpm -r run lint",
     "format": "pnpm -r run format"

--- a/services/playtester/package.json
+++ b/services/playtester/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "playtester",
+  "name": "@srv/playtester",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -10,9 +10,18 @@
     "lint": "eslint \"src/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\""
   },
-  "dependencies": {},
+  "dependencies": {
+    "@ir/game-spec": "workspace:^",
+    "bullmq": "^5.12.0",
+    "fast-json-stable-stringify": "^2.1.0",
+    "ioredis": "^5.3.2",
+    "openai": "^4.56.1",
+    "seedrandom": "^3.0.5",
+    "zod": "^3.22.4"
+  },
   "devDependencies": {
     "@types/node": "^20.10.6",
+    "@types/seedrandom": "^3.0.8",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3"
   }

--- a/services/playtester/src/generator.ts
+++ b/services/playtester/src/generator.ts
@@ -1,0 +1,313 @@
+import { createHash } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { Ability, Level } from '@ir/game-spec';
+import stringify from 'fast-json-stable-stringify';
+import IORedis from 'ioredis';
+import OpenAI from 'openai';
+import seedrandom from 'seedrandom';
+import { z } from 'zod';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4.1-mini';
+const OPENAI_REQ_TIMEOUT_MS = Number(process.env.OPENAI_REQ_TIMEOUT_MS ?? '20000');
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+const GEN_MAX_ATTEMPTS = Number(process.env.GEN_MAX_ATTEMPTS ?? '3');
+const GEN_SIMHASH_TTL_SEC = Number(process.env.GEN_SIMHASH_TTL_SEC ?? '604800');
+
+if (!OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is not set');
+}
+
+const openai = new OpenAI({
+  apiKey: OPENAI_API_KEY,
+  timeout: OPENAI_REQ_TIMEOUT_MS,
+});
+
+const redis = new IORedis(REDIS_URL, {
+  enableOfflineQueue: false,
+});
+
+export interface GenerationConstraints {
+  gravityY: number;
+  moveSpeed: number;
+  jumpVelocity: number;
+  maxGapPX: number;
+  minPlatformWidthPX: number;
+  maxStepUpPX: number;
+  targetDurationSec: number;
+}
+
+export const DEFAULT_CONSTRAINTS: GenerationConstraints = {
+  gravityY: 1200,
+  moveSpeed: 180,
+  jumpVelocity: -520,
+  maxGapPX: 140,
+  minPlatformWidthPX: 48,
+  maxStepUpPX: 96,
+  targetDurationSec: 60,
+};
+
+const AbilitySchema = Ability;
+
+interface PromptFragments {
+  system: string;
+  user: string;
+}
+
+class ParseError extends Error {
+  constructor(message: string, public readonly raw: string) {
+    super(message);
+    this.name = 'ParseError';
+  }
+}
+
+function buildMiniExample(seed: string, difficulty: number, abilities: AbilityT): string {
+  const rng = seedrandom(`${seed}|${difficulty}`);
+  const baseY = Math.round(rng() * 100) + 240;
+  const platformWidth = DEFAULT_CONSTRAINTS.minPlatformWidthPX +
+    Math.round(rng() * 32);
+  const gap = Math.min(
+    DEFAULT_CONSTRAINTS.maxGapPX - 10,
+    Math.round(rng() * DEFAULT_CONSTRAINTS.maxGapPX * 0.6),
+  );
+  const secondHeight = baseY - Math.round(rng() * (DEFAULT_CONSTRAINTS.maxStepUpPX - 12));
+
+  const tiles = [
+    {
+      x: 0,
+      y: baseY,
+      w: platformWidth,
+      h: 24,
+      type: 'ground',
+    },
+    {
+      x: platformWidth + gap,
+      y: secondHeight,
+      w: platformWidth + 16,
+      h: 20,
+      type: 'platform',
+    },
+  ];
+
+  const exit = {
+    x: tiles[1].x + tiles[1].w - 24,
+    y: tiles[1].y - 48,
+  };
+
+  const extras: string[] = [];
+  if (abilities.jetpack) {
+    extras.push('Ein Jetpack-Fuel-Item in mittlerer Höhe.');
+  } else if (abilities.shortFly) {
+    extras.push('Optionaler kurzer Luftpfad mit schwebenden Plattformen.');
+  } else {
+    extras.push('Füge sichere Plattformen ohne Fluganforderungen hinzu.');
+  }
+
+  return [
+    'Beispielauszug (nur Teilstruktur, nicht vollständiges Level):',
+    JSON.stringify({ tiles, exit }, null, 2),
+    `Hinweis: ${extras.join(' ')}`,
+  ].join('\n');
+}
+
+type AbilityT = z.infer<typeof AbilitySchema>;
+type LevelShape = z.infer<typeof Level>;
+
+export function makePrompt(
+  seed: string,
+  difficulty: number,
+  abilities: AbilityT,
+  constraints: GenerationConstraints,
+  extraGuidance = '',
+): PromptFragments {
+  const abilitySummary = JSON.stringify(abilities);
+  const constraintLines = [
+    `- Gravitation Y: ${constraints.gravityY} px/s^2`,
+    `- Laufgeschwindigkeit: ${constraints.moveSpeed} px/s`,
+    `- Absprunggeschwindigkeit: ${constraints.jumpVelocity} px/s`,
+    `- Maximale sichere Lücke: ${constraints.maxGapPX} px`,
+    `- Minimale Plattformbreite: ${constraints.minPlatformWidthPX} px`,
+    `- Maximale Stufenhöhe: ${constraints.maxStepUpPX} px`,
+    `- Ziel-Leveldauer: ${constraints.targetDurationSec} Sekunden`,
+    '- Weltkoordinaten in Pixel, Ursprung links oben.',
+    '- Keine überlappenden Tiles, Hazard nur auf betretbarer Höhe, Ausgang erreichbar.',
+    '- Abilities definieren erlaubte Elemente (keine Flugobjekte ohne passende Fähigkeit).',
+  ];
+
+  const example = buildMiniExample(seed, difficulty, abilities);
+
+  const userParts = [
+    `Seed: ${seed}`,
+    `Schwierigkeit: ${difficulty}`,
+    `Abilities: ${abilitySummary}`,
+    'Constraints:',
+    ...constraintLines,
+    example,
+  ];
+
+  if (extraGuidance.trim().length > 0) {
+    userParts.push('Feedback aus letzter Runde:', extraGuidance.trim());
+  }
+
+  return {
+    system: 'Antworte ausschließlich mit JSON, exakt nach Level-Schema. Keine Kommentare, kein Markdown.',
+    user: userParts.join('\n'),
+  };
+}
+
+function extractJson(text: string): string | null {
+  try {
+    JSON.parse(text);
+    return text;
+  } catch (error) {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      const candidate = text.slice(start, end + 1);
+      try {
+        JSON.parse(candidate);
+        return candidate;
+      } catch (error_) {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function createSignature(level: LevelShape): string {
+  const core = stringify({
+    tiles: level.tiles,
+    moving: level.moving ?? [],
+    enemies: level.enemies ?? [],
+    exit: level.exit,
+  });
+  const hash = createHash('sha1');
+  hash.update(core);
+  return hash.digest('hex');
+}
+
+async function isDuplicate(signature: string): Promise<boolean> {
+  const key = `sig:level:${signature}`;
+  const existing = await redis.get(key);
+  return Boolean(existing);
+}
+
+async function rememberSignature(signature: string, levelId: string): Promise<void> {
+  const key = `sig:level:${signature}`;
+  await redis.set(key, levelId, 'EX', GEN_SIMHASH_TTL_SEC);
+}
+
+async function callModel(prompt: PromptFragments) {
+  const response = await openai.responses.create({
+    model: OPENAI_MODEL,
+    input: [
+      {
+        role: 'system',
+        content: [{ type: 'input_text', text: prompt.system }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: prompt.user }],
+      },
+    ],
+    temperature: 0.35,
+    max_output_tokens: 2048,
+  });
+
+  const text = response.output_text ?? '';
+  const usage = response.usage ?? undefined;
+  if (usage) {
+    console.info('[generator] usage', {
+      inputTokens: usage.input_tokens,
+      outputTokens: usage.output_tokens,
+      totalTokens: usage.total_tokens,
+    });
+  }
+  return text;
+}
+
+export async function generateLevel(
+  seed: string,
+  difficulty: number,
+  abilities: AbilityT,
+): Promise<LevelShape> {
+  const parsedAbilities = AbilitySchema.parse(abilities);
+  let guidance = '';
+
+  for (let attempt = 0; attempt < GEN_MAX_ATTEMPTS; attempt += 1) {
+    const attemptSeed = attempt === 0 ? seed : `${seed}-${attempt}`;
+    const prompt = makePrompt(attemptSeed, difficulty, parsedAbilities, DEFAULT_CONSTRAINTS, guidance);
+
+    try {
+      const raw = await callModel(prompt);
+      const candidateJson = extractJson(raw);
+      if (!candidateJson) {
+        throw new ParseError('Antwort konnte nicht als JSON extrahiert werden.', raw);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(candidateJson);
+      } catch (error) {
+        throw new ParseError('Antwort enthielt ungültiges JSON.', candidateJson);
+      }
+
+      const parsedObject =
+        typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {};
+
+      const candidateLevel = Level.parse({
+        ...parsedObject,
+        id: `lvl-${attemptSeed}-${Date.now()}`,
+        seed: attemptSeed,
+        rules: {
+          duration_target_s: DEFAULT_CONSTRAINTS.targetDurationSec,
+          difficulty,
+          abilities: parsedAbilities,
+          ...(typeof parsedObject.rules === 'object' && parsedObject.rules !== null
+            ? (parsedObject.rules as Record<string, unknown>)
+            : {}),
+        },
+      });
+
+      if (candidateLevel.rules.difficulty !== difficulty) {
+        candidateLevel.rules.difficulty = difficulty;
+      }
+      candidateLevel.rules.abilities = parsedAbilities;
+      candidateLevel.rules.duration_target_s = DEFAULT_CONSTRAINTS.targetDurationSec;
+      candidateLevel.seed = attemptSeed;
+
+      const signature = createSignature(candidateLevel);
+      if (await isDuplicate(signature)) {
+        guidance = 'Vorherige Ausgabe duplizierte ein existierendes Layout. Variiere Struktur und Plattform-Anordnung.';
+        continue;
+      }
+
+      await rememberSignature(signature, candidateLevel.id);
+      return candidateLevel;
+    } catch (error) {
+      if (error instanceof ParseError) {
+        guidance = 'Die letzte Antwort war kein gültiges JSON. Gib ausschließlich gültiges JSON zurück.';
+        await delay(250);
+        continue;
+      }
+      if (error instanceof z.ZodError) {
+        guidance = `Schema-Fehler: ${error.issues.map((issue) => issue.message).join('; ')}`;
+        await delay(250);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error('Keine gültige Level-Antwort nach maximalen Versuchen erhalten');
+}
+
+export async function closeGenerator(): Promise<void> {
+  try {
+    await redis.quit();
+  } catch (error) {
+    redis.disconnect();
+  }
+}

--- a/services/playtester/src/internal-client.ts
+++ b/services/playtester/src/internal-client.ts
@@ -1,0 +1,105 @@
+import { Level, LevelT } from '@ir/game-spec';
+import { z } from 'zod';
+
+const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN ?? 'dev-internal';
+const API_BASE_URL = process.env.API_BASE_URL ?? 'http://localhost:3000';
+
+const JobStatusSchema = z.enum(['queued', 'running', 'failed', 'succeeded']);
+const JobTypeSchema = z.enum(['gen', 'test']);
+
+export interface IngestLevelPayload {
+  level: LevelT;
+  difficulty: number;
+  seed: string;
+}
+
+export async function ingestLevel(payload: IngestLevelPayload): Promise<{ id: string }> {
+  const response = await fetch(`${API_BASE_URL}/internal/levels`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({
+      level: Level.parse(payload.level),
+      meta: {
+        difficulty: payload.difficulty,
+        seed: payload.seed,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to ingest level: ${response.status} ${text}`);
+  }
+
+  return response.json() as Promise<{ id: string }>;
+}
+
+export async function createJobRecord(params: {
+  id: string;
+  type: z.infer<typeof JobTypeSchema>;
+  status?: z.infer<typeof JobStatusSchema>;
+  levelId?: string | null;
+}): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/internal/jobs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({
+      id: params.id,
+      type: JobTypeSchema.parse(params.type),
+      status: JobStatusSchema.parse(params.status ?? 'queued'),
+      levelId: params.levelId ?? null,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to create job record: ${response.status} ${text}`);
+  }
+}
+
+export async function updateJobStatus(params: {
+  id: string;
+  status: z.infer<typeof JobStatusSchema>;
+  error?: string;
+  levelId?: string;
+}): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/internal/jobs/${params.id}/status`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({
+      status: JobStatusSchema.parse(params.status),
+      error: params.error ?? null,
+      levelId: params.levelId,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to update job status: ${response.status} ${text}`);
+  }
+}
+
+export async function fetchLevel(levelId: string): Promise<LevelT> {
+  const response = await fetch(`${API_BASE_URL}/levels/${levelId}`, {
+    headers: {
+      accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to fetch level ${levelId}: ${response.status} ${text}`);
+  }
+
+  const data = await response.json();
+  return Level.parse(data);
+}

--- a/services/playtester/src/queue.ts
+++ b/services/playtester/src/queue.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto';
+
+import { Ability } from '@ir/game-spec';
+import { Queue, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+import { z } from 'zod';
+
+import { DEFAULT_CONSTRAINTS, closeGenerator, generateLevel } from './generator';
+import { fetchLevel, ingestLevel, createJobRecord, updateJobStatus } from './internal-client';
+import { runHeuristicChecks } from './tester';
+
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+
+const AbilityInputSchema = Ability;
+
+export interface GenJobData {
+  seed?: string;
+  difficulty?: number;
+  abilities?: z.input<typeof AbilityInputSchema>;
+}
+
+export interface TestJobData {
+  levelId: string;
+}
+
+export interface WorkerRuntime {
+  close(): Promise<void>;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : JSON.stringify(error);
+}
+
+export async function startWorkers(): Promise<WorkerRuntime> {
+  const connection = new IORedis(REDIS_URL);
+
+  const genQueue = new Queue<GenJobData>('gen', {
+    connection,
+    defaultJobOptions: { removeOnComplete: true },
+  });
+  const testQueue = new Queue<TestJobData>('test', {
+    connection,
+    defaultJobOptions: { removeOnComplete: true },
+  });
+
+  const genWorker = new Worker<GenJobData>(
+    'gen',
+    async (job) => {
+      const jobId = job.id ?? randomUUID();
+      try {
+        await updateJobStatus({ id: jobId, status: 'running' });
+
+        const seed = job.data.seed ?? randomUUID();
+        const difficulty = job.data.difficulty ?? 1;
+        const abilityInput = job.data.abilities ?? { run: true, jump: true };
+        const abilities = AbilityInputSchema.parse(abilityInput);
+
+        const level = await generateLevel(seed, difficulty, abilities);
+
+        await ingestLevel({ level, difficulty, seed: level.seed });
+
+        await updateJobStatus({ id: jobId, status: 'succeeded', levelId: level.id });
+
+        const testJobId = randomUUID();
+        await createJobRecord({ id: testJobId, type: 'test', status: 'queued', levelId: level.id });
+        try {
+          await testQueue.add('playtest', { levelId: level.id }, { jobId: testJobId });
+        } catch (error) {
+          const message = toErrorMessage(error);
+          await updateJobStatus({ id: testJobId, status: 'failed', error: message, levelId: level.id });
+          throw error;
+        }
+      } catch (error) {
+        const message = toErrorMessage(error);
+        await updateJobStatus({ id: jobId, status: 'failed', error: message });
+        throw error;
+      }
+    },
+    {
+      connection,
+      concurrency: 2,
+    },
+  );
+
+  const testWorker = new Worker<TestJobData>(
+    'test',
+    async (job) => {
+      const jobId = job.id ?? randomUUID();
+      try {
+        await updateJobStatus({ id: jobId, status: 'running' });
+
+        const level = await fetchLevel(job.data.levelId);
+        const result = runHeuristicChecks(level, DEFAULT_CONSTRAINTS);
+        if (!result.success) {
+          throw new Error(result.reason ?? 'Level failed heuristics');
+        }
+
+        await updateJobStatus({ id: jobId, status: 'succeeded', levelId: job.data.levelId });
+      } catch (error) {
+        const message = toErrorMessage(error);
+        await updateJobStatus({ id: jobId, status: 'failed', error: message });
+        throw error;
+      }
+    },
+    {
+      connection,
+      concurrency: 4,
+    },
+  );
+
+  genWorker.on('failed', (job, error) => {
+    console.error('[genWorker] failed', { jobId: job?.id, error: error?.message });
+  });
+  testWorker.on('failed', (job, error) => {
+    console.error('[testWorker] failed', { jobId: job?.id, error: error?.message });
+  });
+
+  async function close() {
+    await Promise.allSettled([genWorker.close(), testWorker.close()]);
+    await Promise.allSettled([genQueue.close(), testQueue.close()]);
+    try {
+      await connection.quit();
+    } catch (error) {
+      connection.disconnect();
+    }
+    await closeGenerator();
+  }
+
+  return { close };
+}

--- a/services/playtester/src/tester.ts
+++ b/services/playtester/src/tester.ts
@@ -1,0 +1,59 @@
+import { Level, LevelT } from '@ir/game-spec';
+
+import { GenerationConstraints } from './generator';
+
+const WALKABLE_TILE_TYPES: LevelT['tiles'][number]['type'][] = ['ground', 'platform', 'moving'];
+
+export interface TestResult {
+  success: boolean;
+  reason?: string;
+}
+
+export function runHeuristicChecks(level: LevelT, constraints: GenerationConstraints): TestResult {
+  const validated = Level.parse(level);
+  const walkableTiles = validated.tiles
+    .filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type))
+    .sort((a, b) => a.x - b.x);
+
+  if (walkableTiles.length === 0) {
+    return { success: false, reason: 'no_walkable_tiles' };
+  }
+
+  for (const tile of walkableTiles) {
+    if (tile.w < constraints.minPlatformWidthPX) {
+      return { success: false, reason: 'platform_too_narrow' };
+    }
+  }
+
+  for (let i = 0; i < walkableTiles.length - 1; i += 1) {
+    const current = walkableTiles[i];
+    const next = walkableTiles[i + 1];
+    const gap = next.x - (current.x + current.w);
+    if (gap > constraints.maxGapPX) {
+      return { success: false, reason: 'gap_too_wide' };
+    }
+
+    const step = Math.abs(next.y - current.y);
+    if (step > constraints.maxStepUpPX) {
+      return { success: false, reason: 'step_too_high' };
+    }
+  }
+
+  if (validated.exit.x <= walkableTiles[0].x + walkableTiles[0].w) {
+    return { success: false, reason: 'exit_not_reachable' };
+  }
+
+  const hazards = validated.tiles.filter((tile) => tile.type === 'hazard');
+  for (const hazard of hazards) {
+    const overlap = walkableTiles.some((tile) => {
+      const horizontalOverlap = tile.x < hazard.x + hazard.w && hazard.x < tile.x + tile.w;
+      const heightClearance = hazard.y >= tile.y - tile.h && hazard.y <= tile.y + tile.h + 8;
+      return horizontalOverlap && heightClearance;
+    });
+    if (!overlap) {
+      return { success: false, reason: 'hazard_without_platform' };
+    }
+  }
+
+  return { success: true };
+}


### PR DESCRIPTION
## Summary
- implement OpenAI-driven level generator with deterministic prompts, duplicate detection, and retry handling in the playtester service
- add BullMQ workers plus internal API client to store generated levels, enqueue tests, and run heuristic checks
- expose internal API routes for level ingest and job status updates while documenting the new playtester workflow

## Testing
- pnpm --filter @srv/playtester build
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68dd58be50d0832db95e0dea6dca70c2