### PR TITLE
Implement deterministic playtesting and ghost paths

### DIFF
--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -34,6 +34,16 @@ export async function migrate(db: Database.Database): Promise<void> {
     );
   `);
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS level_paths (
+      level_id TEXT PRIMARY KEY,
+      path_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(level_id) REFERENCES levels(id)
+    );
+  `);
+
   db.exec(`CREATE INDEX IF NOT EXISTS idx_levels_published ON levels(published);`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);`);
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,17 +1,81 @@
 import cors from '@fastify/cors';
 import type Database from 'better-sqlite3';
-import Fastify from 'fastify';
+import Fastify, { type FastifyRequest } from 'fastify';
 import type IORedis from 'ioredis';
 import pino from 'pino';
+import { z } from 'zod';
 
-import { pingDb } from './db';
+import { Ability, Level } from '@ir/game-spec';
+
+import {
+  getJob,
+  getLevel,
+  getLevelPath,
+  insertJob,
+  insertLevel,
+  pingDb,
+  upsertLevelPath,
+  updateJobStatus,
+} from './db';
+import type { QueueManager } from './queue';
 
 interface BuildServerOptions {
   db: Database.Database;
   redis: IORedis;
+  queueManager: QueueManager;
 }
 
-export function buildServer({ db, redis }: BuildServerOptions) {
+const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN ?? 'dev-internal';
+
+function requireInternalToken(request: FastifyRequest): void {
+  const token = request.headers['x-internal-token'];
+  if ((Array.isArray(token) ? token[0] : token) !== INTERNAL_TOKEN) {
+    throw new Error('unauthorized');
+  }
+}
+
+const GenerateBody = z.object({
+  seed: z.string().optional(),
+  difficulty: z.number().int().min(1).optional(),
+  abilities: Ability.optional(),
+});
+
+const IngestBody = z.object({
+  level: Level,
+  meta: z.object({
+    difficulty: z.number().int().min(1),
+    seed: z.string(),
+  }),
+});
+
+const InternalJobBody = z.object({
+  id: z.string(),
+  type: z.enum(['gen', 'test']),
+  status: z.enum(['queued', 'running', 'failed', 'succeeded']).default('queued'),
+  levelId: z.string().nullable().optional(),
+});
+
+const UpdateJobBody = z.object({
+  status: z.enum(['queued', 'running', 'failed', 'succeeded']),
+  error: z.string().nullable().optional(),
+  levelId: z.string().optional(),
+});
+
+const InputCmdSchema = z.object({
+  t: z.number().int().min(0),
+  left: z.boolean().optional(),
+  right: z.boolean().optional(),
+  jump: z.boolean().optional(),
+  fly: z.boolean().optional(),
+  thrust: z.boolean().optional(),
+});
+
+const InternalPathBody = z.object({
+  level_id: z.string(),
+  path: z.array(InputCmdSchema),
+});
+
+export function buildServer({ db, redis, queueManager }: BuildServerOptions) {
   const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
   const server = Fastify({ logger });
 
@@ -43,16 +107,110 @@ export function buildServer({ db, redis }: BuildServerOptions) {
     };
   });
 
-  const noopResponse = { status: 'not-implemented' } as const;
+  server.post('/levels/generate', async (request, reply) => {
+    const body = GenerateBody.parse(request.body ?? {});
+    const jobId = await queueManager.enqueueGen({
+      seed: body.seed,
+      difficulty: body.difficulty,
+      abilities: body.abilities,
+    });
+    reply.status(202).send({ job_id: jobId });
+  });
 
-  server.all('/levels', async () => noopResponse);
-  server.all('/levels/:id', async () => noopResponse);
-  server.all('/jobs/:id', async () => noopResponse);
-  server.all('/levels/:id/publish', async () => noopResponse);
-  server.all('/levels/generate', async () => noopResponse);
-  server.all('/internal/levels', async () => noopResponse);
-  server.all('/internal/jobs', async () => noopResponse);
-  server.all('/internal/jobs/:id/status', async () => noopResponse);
+  server.get('/levels/:id', async (request, reply) => {
+    const id = z.string().parse((request.params as any).id);
+    const level = getLevel(id);
+    if (!level) {
+      reply.status(404).send({ error: 'not_found' });
+      return;
+    }
+    reply.send(level);
+  });
+
+  server.get('/levels/:id/path', async (request, reply) => {
+    const id = z.string().parse((request.params as any).id);
+    const level = getLevel(id);
+    if (!level) {
+      reply.status(404).send({ error: 'not_found' });
+      return;
+    }
+
+    const path = getLevelPath(id);
+    if (!path) {
+      reply.status(404).send({ error: 'path_not_found' });
+      return;
+    }
+    reply.send({ level_id: id, path });
+  });
+
+  server.get('/jobs/:id', async (request, reply) => {
+    const id = z.string().parse((request.params as any).id);
+    const job = getJob(id);
+    if (!job) {
+      reply.status(404).send({ error: 'not_found' });
+      return;
+    }
+    reply.send(job);
+  });
+
+  server.post('/internal/levels', async (request, reply) => {
+    try {
+      requireInternalToken(request);
+    } catch (error) {
+      reply.status(401).send({ error: 'unauthorized' });
+      return;
+    }
+
+    const body = IngestBody.parse(request.body ?? {});
+    insertLevel(body.level, { difficulty: body.meta.difficulty, seed: body.meta.seed });
+    reply.status(201).send({ id: body.level.id });
+  });
+
+  server.post('/internal/jobs', async (request, reply) => {
+    try {
+      requireInternalToken(request);
+    } catch (error) {
+      reply.status(401).send({ error: 'unauthorized' });
+      return;
+    }
+
+    const body = InternalJobBody.parse(request.body ?? {});
+    insertJob({ id: body.id, type: body.type, status: body.status, level_id: body.levelId ?? null });
+    reply.status(204).send();
+  });
+
+  server.post('/internal/jobs/:id/status', async (request, reply) => {
+    try {
+      requireInternalToken(request);
+    } catch (error) {
+      reply.status(401).send({ error: 'unauthorized' });
+      return;
+    }
+
+    const id = z.string().parse((request.params as any).id);
+    const body = UpdateJobBody.parse(request.body ?? {});
+    updateJobStatus(id, body.status, { error: body.error ?? undefined, levelId: body.levelId });
+    reply.status(204).send();
+  });
+
+  server.post('/internal/levels/path', async (request, reply) => {
+    try {
+      requireInternalToken(request);
+    } catch (error) {
+      reply.status(401).send({ error: 'unauthorized' });
+      return;
+    }
+
+    const body = InternalPathBody.parse(request.body ?? {});
+    const level = getLevel(body.level_id);
+    if (!level) {
+      reply.status(404).send({ error: 'level_not_found' });
+      return;
+    }
+
+    upsertLevelPath(body.level_id, body.path);
+    reply.status(204).send();
+  });
 
   server.setNotFoundHandler((_request, reply) => {
     reply.status(404).send({ status: 'not-found' });

--- a/apps/web/src/level/loader.ts
+++ b/apps/web/src/level/loader.ts
@@ -51,3 +51,33 @@ export async function fetchLevel(id: string): Promise<LevelT> {
     return level;
   }
 }
+
+export interface LevelPathEntry {
+  t: number;
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  fly?: boolean;
+  thrust?: boolean;
+}
+
+export async function fetchLevelPath(id: string): Promise<LevelPathEntry[] | null> {
+  const url = `${API_BASE_URL}/levels/${id}/path`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      if (response.status === 404) {
+        return null;
+      }
+      throw new Error(`Failed to load level path: ${response.status} ${response.statusText}`);
+    }
+    const payload = await response.json();
+    if (!Array.isArray(payload.path)) {
+      return null;
+    }
+    return payload.path as LevelPathEntry[];
+  } catch (error) {
+    console.warn(`Konnte Ghost-Path für Level ${id} nicht laden.`, error);
+    return null;
+  }
+}

--- a/services/playtester/src/internal-client.ts
+++ b/services/playtester/src/internal-client.ts
@@ -1,6 +1,8 @@
 import { Level, LevelT } from '@ir/game-spec';
 import { z } from 'zod';
 
+import { InputCmd } from './sim/arcade';
+
 const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN ?? 'dev-internal';
 const API_BASE_URL = process.env.API_BASE_URL ?? 'http://localhost:3000';
 
@@ -102,4 +104,23 @@ export async function fetchLevel(levelId: string): Promise<LevelT> {
 
   const data = await response.json();
   return Level.parse(data);
+}
+
+export async function submitLevelPath(params: { levelId: string; path: InputCmd[] }): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/internal/levels/path`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({
+      level_id: params.levelId,
+      path: params.path,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to submit level path: ${response.status} ${text}`);
+  }
 }

--- a/services/playtester/src/sim/arcade.ts
+++ b/services/playtester/src/sim/arcade.ts
@@ -1,0 +1,349 @@
+import { LevelT } from '@ir/game-spec';
+
+export const DT = 1 / 60;
+export const GRAVITY_Y = 1200;
+export const MOVE_SPEED = 180;
+export const JUMP_VY = -520;
+export const COYOTE_MS = 90;
+export const JUMPBUFFER_MS = 100;
+
+export const PLAYER_WIDTH = 24;
+export const PLAYER_HEIGHT = 32;
+
+export type GridHash = Set<string>;
+
+export interface InputCmd {
+  t: number;
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  fly?: boolean;
+  thrust?: boolean;
+}
+
+export interface InputState {
+  left: boolean;
+  right: boolean;
+  jump: boolean;
+  fly: boolean;
+  thrust: boolean;
+}
+
+export interface PlayerState {
+  frame: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  onGround: boolean;
+  coyoteTimerMs: number;
+  jumpBufferMs: number;
+  shortFlyAvailable: boolean;
+  jetpackFuel: number;
+}
+
+export interface StepContext {
+  abilities: LevelT['rules']['abilities'];
+  tiles: LevelT['tiles'];
+  hazards: LevelT['tiles'];
+}
+
+export interface StepResult extends PlayerState {
+  collidedHazard: boolean;
+  terminated: boolean;
+}
+
+export interface SpawnInfo {
+  x: number;
+  y: number;
+}
+
+export interface SimResult {
+  ok: boolean;
+  reason?: string;
+  frames: number;
+  x: number;
+  y: number;
+  visited: GridHash;
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normaliseInput(input?: InputCmd): InputState {
+  return {
+    left: Boolean(input?.left),
+    right: Boolean(input?.right),
+    jump: Boolean(input?.jump),
+    fly: Boolean(input?.fly),
+    thrust: Boolean(input?.thrust),
+  };
+}
+
+function quantisePosition(value: number): number {
+  return Math.round(value / 2) * 2;
+}
+
+export function createSpawn(level: LevelT): SpawnInfo | null {
+  const walkable = level.tiles
+    .filter((tile) => tile.type === 'ground' || tile.type === 'platform')
+    .sort((a, b) => a.x - b.x);
+
+  const first = walkable[0];
+  if (!first) {
+    return null;
+  }
+
+  const spawnX = first.x + Math.min(32, Math.max(8, PLAYER_WIDTH));
+  const spawnY = first.y - PLAYER_HEIGHT;
+
+  return { x: spawnX, y: spawnY };
+}
+
+export function initialPlayerState(level: LevelT): PlayerState | null {
+  const spawn = createSpawn(level);
+  if (!spawn) {
+    return null;
+  }
+
+  const abilities = level.rules.abilities;
+  const jetpackFuel = abilities.jetpack ? abilities.jetpack.fuel : 0;
+
+  const tiles = level.tiles.filter((tile) => tile.type === 'ground' || tile.type === 'platform');
+  const playerRect: Rect = { x: spawn.x, y: spawn.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+  const onGround = tiles.some((tile) => {
+    const isBelow = Math.abs(playerRect.y + playerRect.h - tile.y) <= 1;
+    const horizontalOverlap = playerRect.x + playerRect.w > tile.x && playerRect.x < tile.x + tile.w;
+    return isBelow && horizontalOverlap;
+  });
+
+  return {
+    frame: 0,
+    x: spawn.x,
+    y: spawn.y,
+    vx: 0,
+    vy: 0,
+    onGround,
+    coyoteTimerMs: 0,
+    jumpBufferMs: 0,
+    shortFlyAvailable: true,
+    jetpackFuel,
+  };
+}
+
+function resolveHorizontalCollisions(state: PlayerState, tiles: Rect[]): void {
+  if (state.vx === 0) {
+    return;
+  }
+
+  const nextX = state.x + state.vx * DT;
+  const playerRect: Rect = { x: nextX, y: state.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+
+  for (const tile of tiles) {
+    if (rectsOverlap(playerRect, tile)) {
+      if (state.vx > 0) {
+        playerRect.x = tile.x - PLAYER_WIDTH;
+      } else if (state.vx < 0) {
+        playerRect.x = tile.x + tile.w;
+      }
+      state.vx = 0;
+    }
+  }
+
+  state.x = playerRect.x;
+}
+
+function resolveVerticalCollisions(state: PlayerState, tiles: Rect[]): void {
+  const nextY = state.y + state.vy * DT;
+  const playerRect: Rect = { x: state.x, y: nextY, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+
+  let onGround = false;
+
+  for (const tile of tiles) {
+    if (!rectsOverlap(playerRect, tile)) {
+      continue;
+    }
+
+    if (state.vy > 0) {
+      playerRect.y = tile.y - PLAYER_HEIGHT;
+      state.vy = 0;
+      onGround = true;
+    } else if (state.vy < 0) {
+      playerRect.y = tile.y + tile.h;
+      state.vy = 0;
+    }
+  }
+
+  state.y = playerRect.y;
+  state.onGround = onGround;
+}
+
+function applyJump(state: PlayerState, abilities: LevelT['rules']['abilities']): void {
+  if (state.jumpBufferMs <= 0) {
+    return;
+  }
+  if (!state.onGround && state.coyoteTimerMs <= 0) {
+    return;
+  }
+
+  const jumpStrength = abilities.highJump ? JUMP_VY * 1.2 : JUMP_VY;
+
+  state.vy = jumpStrength;
+  state.onGround = false;
+  state.coyoteTimerMs = 0;
+  state.jumpBufferMs = 0;
+  if (abilities.shortFly) {
+    state.shortFlyAvailable = false;
+  }
+}
+
+function applyShortFly(state: PlayerState, abilities: LevelT['rules']['abilities'], input: InputState): void {
+  if (!abilities.shortFly) {
+    return;
+  }
+  if (!input.fly || state.onGround || !state.shortFlyAvailable) {
+    return;
+  }
+
+  state.vy = Math.min(state.vy, JUMP_VY * 0.6);
+  state.shortFlyAvailable = false;
+}
+
+function applyJetpack(state: PlayerState, abilities: LevelT['rules']['abilities'], input: InputState): void {
+  if (!abilities.jetpack) {
+    return;
+  }
+  if (!input.thrust || state.jetpackFuel <= 0) {
+    return;
+  }
+
+  const thrust = abilities.jetpack.thrust;
+  state.vy += thrust * DT;
+  state.jetpackFuel = clamp(state.jetpackFuel - 1, 0, abilities.jetpack.fuel);
+}
+
+export function step(level: LevelT, previousState: PlayerState, rawInput: InputCmd | InputState): StepResult {
+  const abilities = level.rules.abilities;
+  const tiles = level.tiles.filter((tile) => tile.type === 'ground' || tile.type === 'platform');
+  const hazards = level.tiles.filter((tile) => tile.type === 'hazard');
+
+  const input = 'left' in rawInput ? (rawInput as InputState) : normaliseInput(rawInput as InputCmd);
+  const next: PlayerState = {
+    ...previousState,
+    frame: previousState.frame + 1,
+    x: previousState.x,
+    y: previousState.y,
+    vx: 0,
+    vy: previousState.vy,
+    onGround: previousState.onGround,
+    coyoteTimerMs: previousState.coyoteTimerMs,
+    jumpBufferMs: previousState.jumpBufferMs,
+    shortFlyAvailable: previousState.shortFlyAvailable,
+    jetpackFuel: previousState.jetpackFuel,
+  };
+
+  next.vx = input.left === input.right ? 0 : input.left ? -MOVE_SPEED : MOVE_SPEED;
+
+  if (next.onGround) {
+    next.coyoteTimerMs = COYOTE_MS;
+    next.shortFlyAvailable = true;
+  } else {
+    next.coyoteTimerMs = Math.max(0, next.coyoteTimerMs - DT * 1000);
+  }
+
+  if (input.jump) {
+    next.jumpBufferMs = JUMPBUFFER_MS;
+  } else {
+    next.jumpBufferMs = Math.max(0, next.jumpBufferMs - DT * 1000);
+  }
+
+  applyJump(next, abilities);
+  applyShortFly(next, abilities, input);
+  applyJetpack(next, abilities, input);
+
+  next.vy += GRAVITY_Y * DT;
+
+  resolveHorizontalCollisions(next, tiles);
+  resolveVerticalCollisions(next, tiles);
+
+  const playerRect: Rect = { x: next.x, y: next.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+  const collidedHazard = hazards.some((hazard) => rectsOverlap(playerRect, hazard));
+
+  return {
+    ...next,
+    collidedHazard,
+    terminated: false,
+  };
+}
+
+export function simulate(level: LevelT, inputs: InputCmd[]): SimResult {
+  const baseState = initialPlayerState(level);
+  if (!baseState) {
+    return { ok: false, reason: 'no_spawn', frames: 0, x: 0, y: 0, visited: new Set() };
+  }
+
+  const visited: GridHash = new Set();
+  const sortedInputs = [...inputs].sort((a, b) => a.t - b.t);
+  let currentInput: InputState = normaliseInput(sortedInputs[0]);
+  if (sortedInputs.length === 0) {
+    currentInput = normaliseInput();
+  }
+  let nextCmdIndex = 1;
+
+  let state: PlayerState = { ...baseState };
+  let frame = 0;
+
+  const maxFrame = (sortedInputs.at(-1)?.t ?? 0) * 2 + 600;
+
+  const hazards = level.tiles.filter((tile) => tile.type === 'hazard');
+  const exitRect: Rect = { x: level.exit.x - 16, y: level.exit.y - 48, w: 32, h: 48 };
+
+  while (frame < maxFrame) {
+    const inputFrame = Math.floor(frame / 2);
+    if (nextCmdIndex < sortedInputs.length && sortedInputs[nextCmdIndex].t <= inputFrame) {
+      currentInput = normaliseInput(sortedInputs[nextCmdIndex]);
+      nextCmdIndex += 1;
+    }
+
+    const result = step(level, state, currentInput);
+    state = result;
+
+    const key = `${Math.floor(state.frame / 2)}:${quantisePosition(state.x)}:${quantisePosition(state.y)}`;
+    visited.add(key);
+
+    const playerRect: Rect = { x: state.x, y: state.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+    if (rectsOverlap(playerRect, exitRect)) {
+      return { ok: true, frames: state.frame, x: state.x, y: state.y, visited };
+    }
+
+    if (result.collidedHazard || hazards.some((hazard) => rectsOverlap(playerRect, hazard))) {
+      return { ok: false, reason: 'hazard', frames: state.frame, x: state.x, y: state.y, visited };
+    }
+
+    frame += 1;
+  }
+
+  return { ok: false, reason: 'timeout', frames: state.frame, x: state.x, y: state.y, visited };
+}
+
+export function maxJumpGapPX(highJump = false): number {
+  const jumpVelocity = highJump ? JUMP_VY * 1.2 : JUMP_VY;
+  const timeUp = Math.abs(jumpVelocity) / GRAVITY_Y;
+  const totalTime = timeUp * 2;
+  return MOVE_SPEED * totalTime;
+}

--- a/services/playtester/src/sim/search.ts
+++ b/services/playtester/src/sim/search.ts
@@ -1,0 +1,373 @@
+import { LevelT } from '@ir/game-spec';
+
+import {
+  MOVE_SPEED,
+  PLAYER_HEIGHT,
+  PLAYER_WIDTH,
+  InputState,
+  PlayerState,
+  initialPlayerState,
+  maxJumpGapPX,
+  step,
+} from './arcade';
+
+interface Action {
+  name: string;
+  input: InputState;
+}
+
+interface SearchNode {
+  state: PlayerState;
+  g: number;
+  h: number;
+  f: number;
+  key: string;
+  parent?: SearchNode;
+  action?: Action;
+  stepIndex: number;
+  direction: number;
+}
+
+export interface SearchOptions {
+  timeLimitMs: number;
+  maxNodes: number;
+}
+
+export interface SearchOutcome {
+  ok: boolean;
+  reason?: string;
+  path?: InputState[];
+  nodesExpanded: number;
+  visitedStates: number;
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y;
+}
+
+function makeExitRect(level: LevelT): Rect {
+  return { x: level.exit.x - 16, y: level.exit.y - 48, w: 32, h: 48 };
+}
+
+function toInputState(action: Partial<InputState>): InputState {
+  return {
+    left: Boolean(action.left),
+    right: Boolean(action.right),
+    jump: Boolean(action.jump),
+    fly: Boolean(action.fly),
+    thrust: Boolean(action.thrust),
+  };
+}
+
+function buildActions(level: LevelT): Action[] {
+  const base: Action[] = [
+    { name: 'idle', input: toInputState({}) },
+    { name: 'left', input: toInputState({ left: true }) },
+    { name: 'right', input: toInputState({ right: true }) },
+    { name: 'jump', input: toInputState({ jump: true }) },
+    { name: 'left_jump', input: toInputState({ left: true, jump: true }) },
+    { name: 'right_jump', input: toInputState({ right: true, jump: true }) },
+  ];
+
+  if (level.rules.abilities.shortFly) {
+    base.push({ name: 'fly', input: toInputState({ fly: true }) });
+    base.push({ name: 'fly_right', input: toInputState({ right: true, fly: true }) });
+    base.push({ name: 'fly_left', input: toInputState({ left: true, fly: true }) });
+  }
+
+  if (level.rules.abilities.jetpack) {
+    base.push({ name: 'thrust', input: toInputState({ thrust: true }) });
+    base.push({ name: 'thrust_right', input: toInputState({ right: true, thrust: true }) });
+    base.push({ name: 'thrust_left', input: toInputState({ left: true, thrust: true }) });
+  }
+
+  return base;
+}
+
+function directionFor(input: InputState): number {
+  if (input.left && !input.right) {
+    return -1;
+  }
+  if (input.right && !input.left) {
+    return 1;
+  }
+  return 0;
+}
+
+function quantise(value: number, stepSize: number): number {
+  return Math.round(value / stepSize) * stepSize;
+}
+
+function stateKey(state: PlayerState): string {
+  const x = quantise(state.x, 2);
+  const y = quantise(state.y, 2);
+  const vx = quantise(state.vx, 2);
+  const vy = quantise(state.vy, 2);
+  const framePhase = state.frame % 120;
+  const ground = state.onGround ? 1 : 0;
+  const fly = state.shortFlyAvailable ? 1 : 0;
+  const fuel = Math.round(state.jetpackFuel);
+  return `${framePhase}|${x}|${y}|${vx}|${vy}|${ground}|${fly}|${fuel}`;
+}
+
+function heuristic(state: PlayerState, exitRect: Rect): number {
+  const dx = Math.max(0, exitRect.x - state.x);
+  const seconds = dx / MOVE_SPEED;
+  return seconds * 30;
+}
+
+function advance(level: LevelT, state: PlayerState, action: Action): { next: PlayerState; hazard: boolean } {
+  let current = state;
+  let hazard = false;
+  for (let i = 0; i < 2; i += 1) {
+    const result = step(level, current, action.input);
+    hazard = hazard || result.collidedHazard;
+    current = result;
+  }
+  return { next: current, hazard };
+}
+
+function reconstructPath(node: SearchNode): InputState[] {
+  const states: InputState[] = [];
+  let current: SearchNode | undefined = node;
+  while (current && current.parent && current.action) {
+    const input = current.action.input;
+    states.push({ ...input });
+    current = current.parent;
+  }
+  states.reverse();
+  return states;
+}
+
+function computeWorldHeight(level: LevelT): number {
+  const tileMax = level.tiles.reduce((max, tile) => Math.max(max, tile.y + tile.h), 0);
+  return Math.max(tileMax, level.exit.y);
+}
+
+function buildGapMap(level: LevelT): Array<{ fromX: number; toX: number; gap: number; y: number }> {
+  const walkable = level.tiles
+    .filter((tile) => tile.type === 'ground' || tile.type === 'platform')
+    .sort((a, b) => a.x - b.x);
+
+  const gaps: Array<{ fromX: number; toX: number; gap: number; y: number }> = [];
+  for (let i = 0; i < walkable.length - 1; i += 1) {
+    const current = walkable[i];
+    const next = walkable[i + 1];
+    const gap = next.x - (current.x + current.w);
+    if (gap > 0) {
+      gaps.push({ fromX: current.x + current.w, toX: next.x, gap, y: current.y });
+    }
+  }
+  return gaps;
+}
+
+function violatesGapPrune(state: PlayerState, action: Action, gaps: Array<{ fromX: number; toX: number; gap: number; y: number }>, maxGap: number): boolean {
+  if (action.input.right === false || action.input.left) {
+    return false;
+  }
+  const playerBottom = state.y + PLAYER_HEIGHT;
+  for (const gap of gaps) {
+    if (state.x <= gap.fromX && playerBottom <= gap.y + 2 && playerBottom >= gap.y - PLAYER_HEIGHT) {
+      if (gap.gap > maxGap) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+class PriorityQueue {
+  private heap: SearchNode[] = [];
+
+  push(node: SearchNode) {
+    this.heap.push(node);
+    this.bubbleUp(this.heap.length - 1);
+  }
+
+  pop(): SearchNode | undefined {
+    if (this.heap.length === 0) {
+      return undefined;
+    }
+    const first = this.heap[0];
+    const last = this.heap.pop();
+    if (!last) {
+      return first;
+    }
+    if (this.heap.length > 0) {
+      this.heap[0] = last;
+      this.bubbleDown(0);
+    }
+    return first;
+  }
+
+  get length(): number {
+    return this.heap.length;
+  }
+
+  private bubbleUp(index: number) {
+    let current = index;
+    while (current > 0) {
+      const parent = Math.floor((current - 1) / 2);
+      if (this.heap[current].f >= this.heap[parent].f) {
+        break;
+      }
+      [this.heap[current], this.heap[parent]] = [this.heap[parent], this.heap[current]];
+      current = parent;
+    }
+  }
+
+  private bubbleDown(index: number) {
+    let current = index;
+    const length = this.heap.length;
+    while (true) {
+      const left = current * 2 + 1;
+      const right = left + 1;
+      let smallest = current;
+      if (left < length && this.heap[left].f < this.heap[smallest].f) {
+        smallest = left;
+      }
+      if (right < length && this.heap[right].f < this.heap[smallest].f) {
+        smallest = right;
+      }
+      if (smallest === current) {
+        break;
+      }
+      [this.heap[current], this.heap[smallest]] = [this.heap[smallest], this.heap[current]];
+      current = smallest;
+    }
+  }
+}
+
+export function searchLevel(level: LevelT, options: SearchOptions): SearchOutcome {
+  const startState = initialPlayerState(level);
+  if (!startState) {
+    return { ok: false, reason: 'no_spawn', nodesExpanded: 0, visitedStates: 0 };
+  }
+
+  const exitRect = makeExitRect(level);
+  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + 24;
+  const worldHeight = computeWorldHeight(level);
+  const gaps = buildGapMap(level);
+
+  const startNode: SearchNode = {
+    state: startState,
+    g: 0,
+    h: heuristic(startState, exitRect),
+    f: heuristic(startState, exitRect),
+    key: stateKey(startState),
+    parent: undefined,
+    action: undefined,
+    stepIndex: 0,
+    direction: 0,
+  };
+
+  const open = new PriorityQueue();
+  open.push(startNode);
+
+  const visited = new Map<string, number>();
+  visited.set(startNode.key, 0);
+
+  const actions = buildActions(level);
+
+  const startTime = Date.now();
+  let nodesExpanded = 0;
+  let visitedStates = 0;
+  let bestX = startState.x;
+
+  while (open.length > 0) {
+    if (Date.now() - startTime > options.timeLimitMs) {
+      return { ok: false, reason: 'timeout', nodesExpanded, visitedStates };
+    }
+    if (nodesExpanded >= options.maxNodes) {
+      return { ok: false, reason: 'timeout', nodesExpanded, visitedStates };
+    }
+
+    const current = open.pop();
+    if (!current) {
+      break;
+    }
+    nodesExpanded += 1;
+    visitedStates = visited.size;
+
+    const playerRect: Rect = { x: current.state.x, y: current.state.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+    if (rectsOverlap(playerRect, exitRect)) {
+      const states = reconstructPath(current);
+      return { ok: true, path: states, nodesExpanded, visitedStates };
+    }
+
+    if (current.state.x > bestX) {
+      bestX = current.state.x;
+    }
+
+    for (const action of actions) {
+      if (violatesGapPrune(current.state, action, gaps, maxGap)) {
+        continue;
+      }
+
+      const { next, hazard } = advance(level, current.state, action);
+      if (hazard) {
+        continue;
+      }
+
+      if (next.y > worldHeight + 200) {
+        continue;
+      }
+
+      if (next.x < bestX - 200) {
+        continue;
+      }
+
+      const newDir = directionFor(action.input);
+      if (current.parent && current.action) {
+        const prevDir = current.direction;
+        const parentDir = current.parent.direction;
+        if (prevDir !== 0 && newDir !== 0 && Math.sign(prevDir) !== Math.sign(newDir)) {
+          const ancestor = current.parent.state;
+          if (Math.abs(next.x - ancestor.x) < 4) {
+            continue;
+          }
+        }
+        if (parentDir !== 0 && newDir !== 0 && Math.sign(parentDir) !== Math.sign(newDir)) {
+          const grand = current.parent.parent?.state ?? current.parent.state;
+          if (Math.abs(next.x - grand.x) < 4) {
+            continue;
+          }
+        }
+      }
+
+      const key = stateKey(next);
+      const g = current.g + 1;
+      const previousCost = visited.get(key);
+      if (previousCost !== undefined && previousCost <= g) {
+        continue;
+      }
+      visited.set(key, g);
+
+      const h = heuristic(next, exitRect);
+      const node: SearchNode = {
+        state: next,
+        g,
+        h,
+        f: g + h,
+        key,
+        parent: current,
+        action,
+        stepIndex: current.stepIndex + 1,
+        direction: newDir === 0 ? current.direction : newDir,
+      };
+      open.push(node);
+    }
+  }
+
+  return { ok: false, reason: 'no_path', nodesExpanded, visitedStates };
+}

--- a/services/playtester/src/tester.ts
+++ b/services/playtester/src/tester.ts
@@ -1,59 +1,131 @@
-import { Level, LevelT } from '@ir/game-spec';
+import { LevelT } from '@ir/game-spec';
 
-import { GenerationConstraints } from './generator';
+import { maxJumpGapPX, InputCmd, InputState, simulate } from './sim/arcade';
+import { searchLevel } from './sim/search';
 
-const WALKABLE_TILE_TYPES: LevelT['tiles'][number]['type'][] = ['ground', 'platform', 'moving'];
+const WALKABLE_TILE_TYPES: LevelT['tiles'][number]['type'][] = ['ground', 'platform'];
 
-export interface TestResult {
-  success: boolean;
+interface PrecheckResult {
+  ok: boolean;
   reason?: string;
 }
 
-export function runHeuristicChecks(level: LevelT, constraints: GenerationConstraints): TestResult {
-  const validated = Level.parse(level);
-  const walkableTiles = validated.tiles
-    .filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type))
-    .sort((a, b) => a.x - b.x);
-
-  if (walkableTiles.length === 0) {
-    return { success: false, reason: 'no_walkable_tiles' };
+function runPrechecks(level: LevelT): PrecheckResult {
+  const tiles = level.tiles.filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type));
+  if (tiles.length === 0) {
+    return { ok: false, reason: 'no_spawn' };
   }
 
-  for (const tile of walkableTiles) {
-    if (tile.w < constraints.minPlatformWidthPX) {
-      return { success: false, reason: 'platform_too_narrow' };
-    }
-  }
+  tiles.sort((a, b) => a.x - b.x);
 
-  for (let i = 0; i < walkableTiles.length - 1; i += 1) {
-    const current = walkableTiles[i];
-    const next = walkableTiles[i + 1];
+  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + 16;
+  for (let i = 0; i < tiles.length - 1; i += 1) {
+    const current = tiles[i];
+    const next = tiles[i + 1];
     const gap = next.x - (current.x + current.w);
-    if (gap > constraints.maxGapPX) {
-      return { success: false, reason: 'gap_too_wide' };
-    }
-
-    const step = Math.abs(next.y - current.y);
-    if (step > constraints.maxStepUpPX) {
-      return { success: false, reason: 'step_too_high' };
+    if (gap > maxGap) {
+      return { ok: false, reason: 'gap_too_wide' };
     }
   }
 
-  if (validated.exit.x <= walkableTiles[0].x + walkableTiles[0].w) {
-    return { success: false, reason: 'exit_not_reachable' };
-  }
-
-  const hazards = validated.tiles.filter((tile) => tile.type === 'hazard');
+  const hazards = level.tiles.filter((tile) => tile.type === 'hazard');
   for (const hazard of hazards) {
-    const overlap = walkableTiles.some((tile) => {
-      const horizontalOverlap = tile.x < hazard.x + hazard.w && hazard.x < tile.x + tile.w;
-      const heightClearance = hazard.y >= tile.y - tile.h && hazard.y <= tile.y + tile.h + 8;
-      return horizontalOverlap && heightClearance;
+    const hasWindow = tiles.some((tile) => {
+      const horizontal = tile.x < hazard.x + hazard.w && hazard.x < tile.x + tile.w;
+      const vertical = hazard.y >= tile.y - tile.h && hazard.y <= tile.y + 8;
+      return horizontal && vertical;
     });
-    if (!overlap) {
-      return { success: false, reason: 'hazard_without_platform' };
+    if (!hasWindow) {
+      return { ok: false, reason: 'hazard_no_window' };
     }
   }
 
-  return { success: true };
+  return { ok: true };
+}
+
+function compressPath(states: InputState[]): InputCmd[] {
+  const result: InputCmd[] = [];
+  let prev: InputState = { left: false, right: false, jump: false, fly: false, thrust: false };
+
+  states.forEach((state, index) => {
+    const changes: Partial<InputState> = {};
+    if (state.left !== prev.left) {
+      changes.left = state.left;
+    }
+    if (state.right !== prev.right) {
+      changes.right = state.right;
+    }
+    if (state.jump !== prev.jump) {
+      changes.jump = state.jump;
+    }
+    if (state.fly !== prev.fly) {
+      changes.fly = state.fly;
+    }
+    if (state.thrust !== prev.thrust) {
+      changes.thrust = state.thrust;
+    }
+
+    if (Object.keys(changes).length > 0 || index === 0) {
+      result.push({
+        t: index,
+        left: index === 0 ? state.left : changes.left,
+        right: index === 0 ? state.right : changes.right,
+        jump: index === 0 ? state.jump : changes.jump,
+        fly: index === 0 ? state.fly : changes.fly,
+        thrust: index === 0 ? state.thrust : changes.thrust,
+      });
+      prev = { ...state };
+    }
+  });
+
+  return result;
+}
+
+export interface TestLevelResult {
+  ok: boolean;
+  path?: InputCmd[];
+  reason?: string;
+  nodes?: number;
+  visited?: number;
+  durationMs?: number;
+}
+
+export async function testLevel(level: LevelT): Promise<TestLevelResult> {
+  const precheck = runPrechecks(level);
+  if (!precheck.ok) {
+    return { ok: false, reason: precheck.reason };
+  }
+
+  const startedAt = Date.now();
+  const search = searchLevel(level, { timeLimitMs: 3000, maxNodes: 80000 });
+  const durationMs = Date.now() - startedAt;
+  if (!search.ok || !search.path) {
+    return {
+      ok: false,
+      reason: search.reason ?? 'no_path',
+      nodes: search.nodesExpanded,
+      visited: search.visitedStates,
+      durationMs,
+    };
+  }
+
+  const path = compressPath(search.path);
+  const simulation = simulate(level, path);
+  if (!simulation.ok) {
+    return {
+      ok: false,
+      reason: simulation.reason ?? 'no_path',
+      nodes: search.nodesExpanded,
+      visited: search.visitedStates,
+      durationMs,
+    };
+  }
+
+  return {
+    ok: true,
+    path,
+    nodes: search.nodesExpanded,
+    visited: search.visitedStates,
+    durationMs,
+  };
 }


### PR DESCRIPTION
## Summary
- add a deterministic arcade physics simulator and A* input search to the playtester service
- replace the tester workflow and worker integration to compute ghost input paths and submit them to the API
- extend the API and web loader to persist and fetch recorded ghost paths for playback

## Testing
- pnpm --filter playtester build
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68de2c03dea8832dbe658e27b96215f9