### PR TITLE
feat: stabilize playtester env setup and add physics search

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Alle Level-Daten validieren gegen `@ir/game-spec`, persistieren in SQLite (`./ap
   - `REDIS_URL` (Standard: `redis://redis:6379`)
   - `API_BASE_URL` (Standard: `http://localhost:3000`)
   - `INTERNAL_TOKEN` (muss mit der API übereinstimmen, Standard `dev-internal`)
+- Lokale Konfiguration: `.env` im Ordner `services/playtester/` (UTF-8, ohne Anführungszeichen). Änderungen erfordern einen Neustart des Playtester-Services.
 - Queues: `gen` (Concurrency 2) & `test` (Concurrency 4) via BullMQ.
 - Der Worker schreibt Levels und Job-Status über interne API-Endpunkte (`/internal/*`) zurück.
 

--- a/services/playtester/package.json
+++ b/services/playtester/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ir/game-spec": "workspace:^",
     "bullmq": "^5.12.0",
+    "dotenv": "^16.4.5",
     "fast-json-stable-stringify": "^2.1.0",
     "ioredis": "^5.3.2",
     "openai": "^4.56.1",

--- a/services/playtester/src/index.ts
+++ b/services/playtester/src/index.ts
@@ -1,8 +1,18 @@
+import 'dotenv/config';
+
 import { startWorkers } from './queue';
 
 async function bootstrap() {
   const runtime = await startWorkers();
   console.log('[playtester] Workers for gen/test queues started');
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('[playtester] OPENAI_API_KEY is not set. Please configure services/playtester/.env and restart.');
+    await runtime
+      .close()
+      .catch((error) => console.error('[playtester] Failed to close runtime after missing API key', error));
+    process.exit(1);
+  }
 
   let shuttingDown = false;
   const shutdown = async (signal: NodeJS.Signals) => {

--- a/services/playtester/src/queue.ts
+++ b/services/playtester/src/queue.ts
@@ -96,18 +96,17 @@ export async function startWorkers(): Promise<WorkerRuntime> {
         const result = await testLevel(level);
         if (!result.ok || !result.path) {
           const reason = result.reason ?? 'no_path';
+          console.log(
+            `[testWorker] search done nodes=${result.nodes ?? 0} time=${result.durationMs ?? 0}ms result=fail(${reason})`,
+          );
           throw new Error(reason);
         }
 
         await submitLevelPath({ levelId: job.data.levelId, path: result.path });
         await updateJobStatus({ id: jobId, status: 'succeeded', levelId: job.data.levelId });
-        console.log('[testWorker] search done', {
-          jobId,
-          nodes: result.nodes ?? 0,
-          visited: result.visited ?? 0,
-          durationMs: result.durationMs ?? 0,
-          result: 'ok',
-        });
+        console.log(
+          `[testWorker] search done nodes=${result.nodes ?? 0} time=${result.durationMs ?? 0}ms result=ok`,
+        );
       } catch (error) {
         const message = toErrorMessage(error);
         await updateJobStatus({ id: jobId, status: 'failed', error: message, levelId: job.data.levelId });

--- a/services/playtester/src/sim/search.ts
+++ b/services/playtester/src/sim/search.ts
@@ -1,15 +1,20 @@
 import { LevelT } from '@ir/game-spec';
 
 import {
+  INPUT_HZ,
   MOVE_SPEED,
   PLAYER_HEIGHT,
   PLAYER_WIDTH,
+  InputCmd,
   InputState,
   PlayerState,
+  createStepContext,
   initialPlayerState,
   maxJumpGapPX,
   step,
 } from './arcade';
+
+const ACTION_FRAMES = 2;
 
 interface Action {
   name: string;
@@ -21,24 +26,18 @@ interface SearchNode {
   g: number;
   h: number;
   f: number;
-  key: string;
   parent?: SearchNode;
   action?: Action;
-  stepIndex: number;
+  key: string;
   direction: number;
+  stalled: number;
 }
 
-export interface SearchOptions {
-  timeLimitMs: number;
-  maxNodes: number;
-}
-
-export interface SearchOutcome {
-  ok: boolean;
-  reason?: string;
-  path?: InputState[];
-  nodesExpanded: number;
-  visitedStates: number;
+interface GapInfo {
+  fromX: number;
+  toX: number;
+  gap: number;
+  y: number;
 }
 
 interface Rect {
@@ -48,191 +47,51 @@ interface Rect {
   h: number;
 }
 
-function rectsOverlap(a: Rect, b: Rect): boolean {
-  return a.x < b.x + b.w &&
-    a.x + a.w > b.x &&
-    a.y < b.y + b.h &&
-    a.y + a.h > b.y;
-}
+class PriorityQueue<T extends { f: number }> {
+  private heap: T[] = [];
 
-function makeExitRect(level: LevelT): Rect {
-  return { x: level.exit.x - 16, y: level.exit.y - 48, w: 32, h: 48 };
-}
-
-function toInputState(action: Partial<InputState>): InputState {
-  return {
-    left: Boolean(action.left),
-    right: Boolean(action.right),
-    jump: Boolean(action.jump),
-    fly: Boolean(action.fly),
-    thrust: Boolean(action.thrust),
-  };
-}
-
-function buildActions(level: LevelT): Action[] {
-  const base: Action[] = [
-    { name: 'idle', input: toInputState({}) },
-    { name: 'left', input: toInputState({ left: true }) },
-    { name: 'right', input: toInputState({ right: true }) },
-    { name: 'jump', input: toInputState({ jump: true }) },
-    { name: 'left_jump', input: toInputState({ left: true, jump: true }) },
-    { name: 'right_jump', input: toInputState({ right: true, jump: true }) },
-  ];
-
-  if (level.rules.abilities.shortFly) {
-    base.push({ name: 'fly', input: toInputState({ fly: true }) });
-    base.push({ name: 'fly_right', input: toInputState({ right: true, fly: true }) });
-    base.push({ name: 'fly_left', input: toInputState({ left: true, fly: true }) });
-  }
-
-  if (level.rules.abilities.jetpack) {
-    base.push({ name: 'thrust', input: toInputState({ thrust: true }) });
-    base.push({ name: 'thrust_right', input: toInputState({ right: true, thrust: true }) });
-    base.push({ name: 'thrust_left', input: toInputState({ left: true, thrust: true }) });
-  }
-
-  return base;
-}
-
-function directionFor(input: InputState): number {
-  if (input.left && !input.right) {
-    return -1;
-  }
-  if (input.right && !input.left) {
-    return 1;
-  }
-  return 0;
-}
-
-function quantise(value: number, stepSize: number): number {
-  return Math.round(value / stepSize) * stepSize;
-}
-
-function stateKey(state: PlayerState): string {
-  const x = quantise(state.x, 2);
-  const y = quantise(state.y, 2);
-  const vx = quantise(state.vx, 2);
-  const vy = quantise(state.vy, 2);
-  const framePhase = state.frame % 120;
-  const ground = state.onGround ? 1 : 0;
-  const fly = state.shortFlyAvailable ? 1 : 0;
-  const fuel = Math.round(state.jetpackFuel);
-  return `${framePhase}|${x}|${y}|${vx}|${vy}|${ground}|${fly}|${fuel}`;
-}
-
-function heuristic(state: PlayerState, exitRect: Rect): number {
-  const dx = Math.max(0, exitRect.x - state.x);
-  const seconds = dx / MOVE_SPEED;
-  return seconds * 30;
-}
-
-function advance(level: LevelT, state: PlayerState, action: Action): { next: PlayerState; hazard: boolean } {
-  let current = state;
-  let hazard = false;
-  for (let i = 0; i < 2; i += 1) {
-    const result = step(level, current, action.input);
-    hazard = hazard || result.collidedHazard;
-    current = result;
-  }
-  return { next: current, hazard };
-}
-
-function reconstructPath(node: SearchNode): InputState[] {
-  const states: InputState[] = [];
-  let current: SearchNode | undefined = node;
-  while (current && current.parent && current.action) {
-    const input = current.action.input;
-    states.push({ ...input });
-    current = current.parent;
-  }
-  states.reverse();
-  return states;
-}
-
-function computeWorldHeight(level: LevelT): number {
-  const tileMax = level.tiles.reduce((max, tile) => Math.max(max, tile.y + tile.h), 0);
-  return Math.max(tileMax, level.exit.y);
-}
-
-function buildGapMap(level: LevelT): Array<{ fromX: number; toX: number; gap: number; y: number }> {
-  const walkable = level.tiles
-    .filter((tile) => tile.type === 'ground' || tile.type === 'platform')
-    .sort((a, b) => a.x - b.x);
-
-  const gaps: Array<{ fromX: number; toX: number; gap: number; y: number }> = [];
-  for (let i = 0; i < walkable.length - 1; i += 1) {
-    const current = walkable[i];
-    const next = walkable[i + 1];
-    const gap = next.x - (current.x + current.w);
-    if (gap > 0) {
-      gaps.push({ fromX: current.x + current.w, toX: next.x, gap, y: current.y });
-    }
-  }
-  return gaps;
-}
-
-function violatesGapPrune(state: PlayerState, action: Action, gaps: Array<{ fromX: number; toX: number; gap: number; y: number }>, maxGap: number): boolean {
-  if (action.input.right === false || action.input.left) {
-    return false;
-  }
-  const playerBottom = state.y + PLAYER_HEIGHT;
-  for (const gap of gaps) {
-    if (state.x <= gap.fromX && playerBottom <= gap.y + 2 && playerBottom >= gap.y - PLAYER_HEIGHT) {
-      if (gap.gap > maxGap) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-class PriorityQueue {
-  private heap: SearchNode[] = [];
-
-  push(node: SearchNode) {
-    this.heap.push(node);
+  push(item: T): void {
+    this.heap.push(item);
     this.bubbleUp(this.heap.length - 1);
   }
 
-  pop(): SearchNode | undefined {
+  pop(): T | undefined {
     if (this.heap.length === 0) {
       return undefined;
     }
-    const first = this.heap[0];
-    const last = this.heap.pop();
-    if (!last) {
-      return first;
-    }
+    const top = this.heap[0];
+    const end = this.heap.pop()!;
     if (this.heap.length > 0) {
-      this.heap[0] = last;
+      this.heap[0] = end;
       this.bubbleDown(0);
     }
-    return first;
+    return top;
   }
 
   get length(): number {
     return this.heap.length;
   }
 
-  private bubbleUp(index: number) {
+  private bubbleUp(index: number): void {
     let current = index;
     while (current > 0) {
       const parent = Math.floor((current - 1) / 2);
-      if (this.heap[current].f >= this.heap[parent].f) {
+      if (this.heap[parent].f <= this.heap[current].f) {
         break;
       }
-      [this.heap[current], this.heap[parent]] = [this.heap[parent], this.heap[current]];
+      [this.heap[parent], this.heap[current]] = [this.heap[current], this.heap[parent]];
       current = parent;
     }
   }
 
-  private bubbleDown(index: number) {
+  private bubbleDown(index: number): void {
     let current = index;
     const length = this.heap.length;
     while (true) {
       const left = current * 2 + 1;
       const right = left + 1;
       let smallest = current;
+
       if (left < length && this.heap[left].f < this.heap[smallest].f) {
         smallest = left;
       }
@@ -248,73 +107,259 @@ class PriorityQueue {
   }
 }
 
-export function searchLevel(level: LevelT, options: SearchOptions): SearchOutcome {
-  const startState = initialPlayerState(level);
-  if (!startState) {
-    return { ok: false, reason: 'no_spawn', nodesExpanded: 0, visitedStates: 0 };
+function defaultInput(): InputState {
+  return { left: false, right: false, jump: false, fly: false, thrust: false };
+}
+
+function toInputState(partial: Partial<InputState>): InputState {
+  return {
+    left: Boolean(partial.left),
+    right: Boolean(partial.right),
+    jump: Boolean(partial.jump),
+    fly: Boolean(partial.fly),
+    thrust: Boolean(partial.thrust),
+  };
+}
+
+function buildActions(level: LevelT): Action[] {
+  const actions: Action[] = [
+    { name: 'idle', input: toInputState({}) },
+    { name: 'left', input: toInputState({ left: true }) },
+    { name: 'right', input: toInputState({ right: true }) },
+    { name: 'jump', input: toInputState({ jump: true }) },
+    { name: 'left_jump', input: toInputState({ left: true, jump: true }) },
+    { name: 'right_jump', input: toInputState({ right: true, jump: true }) },
+  ];
+
+  if (level.rules.abilities.shortFly) {
+    actions.push({ name: 'fly', input: toInputState({ fly: true }) });
+    actions.push({ name: 'fly_right', input: toInputState({ right: true, fly: true }) });
+    actions.push({ name: 'fly_left', input: toInputState({ left: true, fly: true }) });
   }
 
-  const exitRect = makeExitRect(level);
-  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + 24;
-  const worldHeight = computeWorldHeight(level);
-  const gaps = buildGapMap(level);
+  if (level.rules.abilities.jetpack) {
+    actions.push({ name: 'thrust', input: toInputState({ thrust: true }) });
+    actions.push({ name: 'thrust_right', input: toInputState({ right: true, thrust: true }) });
+    actions.push({ name: 'thrust_left', input: toInputState({ left: true, thrust: true }) });
+  }
 
+  return actions;
+}
+
+function quantise(value: number, step: number): number {
+  return Math.round(value / step) * step;
+}
+
+function computeAbilityMask(level: LevelT): number {
+  let mask = 0;
+  if (level.rules.abilities.highJump) {
+    mask |= 1;
+  }
+  if (level.rules.abilities.shortFly) {
+    mask |= 2;
+  }
+  if (level.rules.abilities.jetpack) {
+    mask |= 4;
+  }
+  return mask;
+}
+
+function stateKey(state: PlayerState, abilityMask: number): string {
+  const x = quantise(state.x, 2);
+  const y = quantise(state.y, 2);
+  const vx = quantise(state.vx, 2);
+  const vy = quantise(state.vy, 2);
+  const onGround = state.onGround ? 1 : 0;
+  const fly = state.shortFlyAvailable ? 1 : 0;
+  const fuel = Math.round(state.jetpackFuel);
+  const framePhase = state.frame % (INPUT_HZ * 8);
+  return `${x}|${y}|${vx}|${vy}|${onGround}|${fly}|${fuel}|${framePhase}|${abilityMask}`;
+}
+
+function heuristic(state: PlayerState, exitX: number): number {
+  const dx = Math.max(0, exitX - state.x);
+  return (dx / MOVE_SPEED) * INPUT_HZ;
+}
+
+function advance(level: LevelT, context: ReturnType<typeof createStepContext>, state: PlayerState, input: InputState) {
+  let current = state;
+  let hazard = false;
+  for (let i = 0; i < ACTION_FRAMES; i += 1) {
+    const { state: next, collidedHazard } = step(level, current, input, context);
+    current = next;
+    hazard ||= collidedHazard;
+  }
+  return { next: current, hazard };
+}
+
+function computeWorldHeight(level: LevelT): number {
+  const tileMax = level.tiles.reduce((max, tile) => Math.max(max, tile.y + tile.h), 0);
+  return Math.max(tileMax, level.exit.y + PLAYER_HEIGHT);
+}
+
+function buildGapMap(level: LevelT): GapInfo[] {
+  const walkable = level.tiles
+    .filter((tile) => tile.type === 'ground' || tile.type === 'platform')
+    .sort((a, b) => a.x - b.x);
+
+  const gaps: GapInfo[] = [];
+  for (let i = 0; i < walkable.length - 1; i += 1) {
+    const current = walkable[i];
+    const next = walkable[i + 1];
+    const gap = next.x - (current.x + current.w);
+    if (gap > 0) {
+      gaps.push({ fromX: current.x + current.w, toX: next.x, gap, y: current.y });
+    }
+  }
+  return gaps;
+}
+
+function violatesGap(state: PlayerState, gaps: GapInfo[], maxGap: number, allowFlight: boolean): boolean {
+  if (allowFlight) {
+    return false;
+  }
+  const playerBottom = state.y + PLAYER_HEIGHT;
+  for (const gap of gaps) {
+    if (gap.gap <= maxGap) {
+      continue;
+    }
+    if (state.x + PLAYER_WIDTH < gap.fromX - 12) {
+      continue;
+    }
+    if (state.x > gap.toX + 12) {
+      continue;
+    }
+    const verticalAligned = playerBottom <= gap.y + PLAYER_HEIGHT && playerBottom >= gap.y - PLAYER_HEIGHT * 2;
+    if (verticalAligned && state.x < gap.toX) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function directionFor(input: InputState): number {
+  if (input.left && !input.right) {
+    return -1;
+  }
+  if (input.right && !input.left) {
+    return 1;
+  }
+  return 0;
+}
+
+function buildExitRect(level: LevelT): Rect {
+  return { x: level.exit.x - PLAYER_WIDTH, y: level.exit.y - PLAYER_HEIGHT, w: PLAYER_WIDTH * 2, h: PLAYER_HEIGHT * 2 };
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function isGoal(state: PlayerState, exitRect: Rect): boolean {
+  const playerRect: Rect = { x: state.x, y: state.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
+  return rectsOverlap(playerRect, exitRect);
+}
+
+function reconstructPath(node: SearchNode): InputCmd[] {
+  const actions: Action[] = [];
+  let current: SearchNode | undefined = node;
+  while (current && current.parent && current.action) {
+    actions.push(current.action);
+    current = current.parent;
+  }
+  actions.reverse();
+
+  const commands: InputCmd[] = [];
+  let prevState = defaultInput();
+  actions.forEach((action, index) => {
+    const input = action.input;
+    const delta: InputCmd = { t: index };
+    let changed = false;
+    (['left', 'right', 'jump', 'fly', 'thrust'] as const).forEach((key) => {
+      if (prevState[key] !== input[key] || index === 0) {
+        delta[key] = input[key];
+        if (prevState[key] !== input[key]) {
+          changed = true;
+        }
+      }
+    });
+    if (index === 0 || changed) {
+      commands.push(delta);
+    }
+    prevState = input;
+  });
+  return commands;
+}
+
+export interface SearchOutcome {
+  ok: boolean;
+  path?: InputCmd[];
+  reason?: string;
+  nodes: number;
+  ms: number;
+}
+
+export function findPath(
+  level: LevelT,
+  timeLimitMs = 3000,
+  nodeLimit = 80000,
+): SearchOutcome {
+  const start = initialPlayerState(level);
+  if (!start) {
+    return { ok: false, reason: 'no_spawn', nodes: 0, ms: 0 };
+  }
+
+  const abilityMask = computeAbilityMask(level);
+  const startKey = stateKey(start, abilityMask);
+  const exitRect = buildExitRect(level);
+  const worldHeight = computeWorldHeight(level);
+  const context = createStepContext(level);
+  const actions = buildActions(level);
+  const gaps = buildGapMap(level);
+  const allowFlight = Boolean(level.rules.abilities.shortFly || level.rules.abilities.jetpack);
+  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + 16;
+
+  const queue = new PriorityQueue<SearchNode>();
+  const best = new Map<string, number>();
   const startNode: SearchNode = {
-    state: startState,
+    state: start,
     g: 0,
-    h: heuristic(startState, exitRect),
-    f: heuristic(startState, exitRect),
-    key: stateKey(startState),
-    parent: undefined,
-    action: undefined,
-    stepIndex: 0,
+    h: heuristic(start, level.exit.x),
+    f: heuristic(start, level.exit.x),
+    key: startKey,
     direction: 0,
+    stalled: 0,
   };
 
-  const open = new PriorityQueue();
-  open.push(startNode);
+  queue.push(startNode);
+  best.set(startKey, 0);
 
-  const visited = new Map<string, number>();
-  visited.set(startNode.key, 0);
+  const started = Date.now();
+  let expanded = 0;
 
-  const actions = buildActions(level);
-
-  const startTime = Date.now();
-  let nodesExpanded = 0;
-  let visitedStates = 0;
-  let bestX = startState.x;
-
-  while (open.length > 0) {
-    if (Date.now() - startTime > options.timeLimitMs) {
-      return { ok: false, reason: 'timeout', nodesExpanded, visitedStates };
-    }
-    if (nodesExpanded >= options.maxNodes) {
-      return { ok: false, reason: 'timeout', nodesExpanded, visitedStates };
+  while (queue.length > 0) {
+    if (Date.now() - started > timeLimitMs) {
+      return { ok: false, reason: 'timeout', nodes: expanded, ms: Date.now() - started };
     }
 
-    const current = open.pop();
-    if (!current) {
-      break;
-    }
-    nodesExpanded += 1;
-    visitedStates = visited.size;
-
-    const playerRect: Rect = { x: current.state.x, y: current.state.y, w: PLAYER_WIDTH, h: PLAYER_HEIGHT };
-    if (rectsOverlap(playerRect, exitRect)) {
-      const states = reconstructPath(current);
-      return { ok: true, path: states, nodesExpanded, visitedStates };
+    const current = queue.pop()!;
+    const bestKnown = best.get(current.key);
+    if (bestKnown !== undefined && bestKnown < current.g) {
+      continue;
     }
 
-    if (current.state.x > bestX) {
-      bestX = current.state.x;
+    if (isGoal(current.state, exitRect)) {
+      const path = reconstructPath(current);
+      return { ok: true, path, nodes: expanded, ms: Date.now() - started };
+    }
+
+    expanded += 1;
+    if (expanded >= nodeLimit) {
+      return { ok: false, reason: 'node_limit', nodes: expanded, ms: Date.now() - started };
     }
 
     for (const action of actions) {
-      if (violatesGapPrune(current.state, action, gaps, maxGap)) {
-        continue;
-      }
-
-      const { next, hazard } = advance(level, current.state, action);
+      const { next, hazard } = advance(level, context, current.state, action.input);
       if (hazard) {
         continue;
       }
@@ -323,51 +368,55 @@ export function searchLevel(level: LevelT, options: SearchOptions): SearchOutcom
         continue;
       }
 
-      if (next.x < bestX - 200) {
+      if (next.furthestX < current.state.furthestX - 200) {
         continue;
       }
 
-      const newDir = directionFor(action.input);
-      if (current.parent && current.action) {
-        const prevDir = current.direction;
-        const parentDir = current.parent.direction;
-        if (prevDir !== 0 && newDir !== 0 && Math.sign(prevDir) !== Math.sign(newDir)) {
-          const ancestor = current.parent.state;
-          if (Math.abs(next.x - ancestor.x) < 4) {
-            continue;
-          }
-        }
-        if (parentDir !== 0 && newDir !== 0 && Math.sign(parentDir) !== Math.sign(newDir)) {
-          const grand = current.parent.parent?.state ?? current.parent.state;
-          if (Math.abs(next.x - grand.x) < 4) {
-            continue;
-          }
-        }
-      }
-
-      const key = stateKey(next);
-      const g = current.g + 1;
-      const previousCost = visited.get(key);
-      if (previousCost !== undefined && previousCost <= g) {
+      if (violatesGap(next, gaps, maxGap, allowFlight)) {
         continue;
       }
-      visited.set(key, g);
 
-      const h = heuristic(next, exitRect);
-      const node: SearchNode = {
+      const dir = directionFor(action.input);
+      const progress = Math.abs(next.x - current.state.x);
+      if (dir !== 0 && current.direction !== 0 && dir !== current.direction && progress < 12) {
+        continue;
+      }
+
+      let stalled = current.stalled;
+      if (progress < 4 && dir !== 0) {
+        stalled += 1;
+        if (stalled >= 3) {
+          continue;
+        }
+      } else if (progress < 2 && dir === 0) {
+        stalled = Math.min(3, stalled + 1);
+      } else {
+        stalled = 0;
+      }
+
+      const nextKey = stateKey(next, abilityMask);
+      const tentativeG = current.g + 1;
+      const known = best.get(nextKey);
+      if (known !== undefined && known <= tentativeG) {
+        continue;
+      }
+
+      const h = heuristic(next, level.exit.x);
+      const child: SearchNode = {
         state: next,
-        g,
+        g: tentativeG,
         h,
-        f: g + h,
-        key,
+        f: tentativeG + h,
         parent: current,
         action,
-        stepIndex: current.stepIndex + 1,
-        direction: newDir === 0 ? current.direction : newDir,
+        key: nextKey,
+        direction: dir,
+        stalled,
       };
-      open.push(node);
+      queue.push(child);
+      best.set(nextKey, tentativeG);
     }
   }
 
-  return { ok: false, reason: 'no_path', nodesExpanded, visitedStates };
+  return { ok: false, reason: 'no_path', nodes: expanded, ms: Date.now() - started };
 }

--- a/services/playtester/src/tester.ts
+++ b/services/playtester/src/tester.ts
@@ -1,27 +1,90 @@
 import { LevelT } from '@ir/game-spec';
 
-import { maxJumpGapPX, InputCmd, InputState, simulate } from './sim/arcade';
-import { searchLevel } from './sim/search';
+import { InputCmd, InputState, createSpawn, maxJumpGapPX, simulate } from './sim/arcade';
+import { findPath } from './sim/search';
 
 const WALKABLE_TILE_TYPES: LevelT['tiles'][number]['type'][] = ['ground', 'platform'];
+const SAFETY_GAP_PX = 16;
+const MIN_PLATFORM_WIDTH = 48;
 
 interface PrecheckResult {
   ok: boolean;
   reason?: string;
 }
 
+function defaultInputState(): InputState {
+  return { left: false, right: false, jump: false, fly: false, thrust: false };
+}
+
+function applyCommand(state: InputState, command: InputCmd): InputState {
+  const next = { ...state };
+  if ('left' in command) {
+    next.left = Boolean(command.left);
+  }
+  if ('right' in command) {
+    next.right = Boolean(command.right);
+  }
+  if ('jump' in command) {
+    next.jump = Boolean(command.jump);
+  }
+  if ('fly' in command) {
+    next.fly = Boolean(command.fly);
+  }
+  if ('thrust' in command) {
+    next.thrust = Boolean(command.thrust);
+  }
+  return next;
+}
+
+function compressPath(commands: InputCmd[]): InputCmd[] {
+  const sorted = [...commands].sort((a, b) => a.t - b.t);
+  const result: InputCmd[] = [];
+  let previous = defaultInputState();
+
+  for (const command of sorted) {
+    const next = applyCommand(previous, command);
+    const delta: InputCmd = { t: command.t };
+    let changed = false;
+
+    (['left', 'right', 'jump', 'fly', 'thrust'] as const).forEach((key) => {
+      if (previous[key] !== next[key] || command.t === 0) {
+        delta[key] = next[key];
+        if (previous[key] !== next[key]) {
+          changed = true;
+        }
+      }
+    });
+
+    if (command.t === 0 || changed) {
+      result.push(delta);
+    }
+
+    previous = next;
+  }
+
+  return result;
+}
+
 function runPrechecks(level: LevelT): PrecheckResult {
-  const tiles = level.tiles.filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type));
-  if (tiles.length === 0) {
+  const spawn = createSpawn(level);
+  if (!spawn) {
     return { ok: false, reason: 'no_spawn' };
   }
 
-  tiles.sort((a, b) => a.x - b.x);
+  if (level.exit.x <= spawn.x) {
+    return { ok: false, reason: 'no_path' };
+  }
 
-  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + 16;
-  for (let i = 0; i < tiles.length - 1; i += 1) {
-    const current = tiles[i];
-    const next = tiles[i + 1];
+  const walkable = level.tiles.filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type));
+  if (walkable.some((tile) => tile.w < MIN_PLATFORM_WIDTH)) {
+    return { ok: false, reason: 'gap_too_wide' };
+  }
+
+  const sorted = [...walkable].sort((a, b) => a.x - b.x);
+  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + SAFETY_GAP_PX;
+  for (let i = 0; i < sorted.length - 1; i += 1) {
+    const current = sorted[i];
+    const next = sorted[i + 1];
     const gap = next.x - (current.x + current.w);
     if (gap > maxGap) {
       return { ok: false, reason: 'gap_too_wide' };
@@ -30,7 +93,7 @@ function runPrechecks(level: LevelT): PrecheckResult {
 
   const hazards = level.tiles.filter((tile) => tile.type === 'hazard');
   for (const hazard of hazards) {
-    const hasWindow = tiles.some((tile) => {
+    const hasWindow = walkable.some((tile) => {
       const horizontal = tile.x < hazard.x + hazard.w && hazard.x < tile.x + tile.w;
       const vertical = hazard.y >= tile.y - tile.h && hazard.y <= tile.y + 8;
       return horizontal && vertical;
@@ -43,51 +106,25 @@ function runPrechecks(level: LevelT): PrecheckResult {
   return { ok: true };
 }
 
-function compressPath(states: InputState[]): InputCmd[] {
-  const result: InputCmd[] = [];
-  let prev: InputState = { left: false, right: false, jump: false, fly: false, thrust: false };
-
-  states.forEach((state, index) => {
-    const changes: Partial<InputState> = {};
-    if (state.left !== prev.left) {
-      changes.left = state.left;
-    }
-    if (state.right !== prev.right) {
-      changes.right = state.right;
-    }
-    if (state.jump !== prev.jump) {
-      changes.jump = state.jump;
-    }
-    if (state.fly !== prev.fly) {
-      changes.fly = state.fly;
-    }
-    if (state.thrust !== prev.thrust) {
-      changes.thrust = state.thrust;
-    }
-
-    if (Object.keys(changes).length > 0 || index === 0) {
-      result.push({
-        t: index,
-        left: index === 0 ? state.left : changes.left,
-        right: index === 0 ? state.right : changes.right,
-        jump: index === 0 ? state.jump : changes.jump,
-        fly: index === 0 ? state.fly : changes.fly,
-        thrust: index === 0 ? state.thrust : changes.thrust,
-      });
-      prev = { ...state };
-    }
-  });
-
-  return result;
-}
-
 export interface TestLevelResult {
   ok: boolean;
   path?: InputCmd[];
   reason?: string;
   nodes?: number;
-  visited?: number;
   durationMs?: number;
+}
+
+function mapSearchReason(reason?: string): string {
+  if (!reason) {
+    return 'no_path';
+  }
+  if (reason === 'timeout' || reason === 'node_limit') {
+    return 'timeout';
+  }
+  if (reason === 'no_spawn') {
+    return 'no_spawn';
+  }
+  return 'no_path';
 }
 
 export async function testLevel(level: LevelT): Promise<TestLevelResult> {
@@ -96,16 +133,13 @@ export async function testLevel(level: LevelT): Promise<TestLevelResult> {
     return { ok: false, reason: precheck.reason };
   }
 
-  const startedAt = Date.now();
-  const search = searchLevel(level, { timeLimitMs: 3000, maxNodes: 80000 });
-  const durationMs = Date.now() - startedAt;
+  const search = findPath(level, 3000, 80000);
   if (!search.ok || !search.path) {
     return {
       ok: false,
-      reason: search.reason ?? 'no_path',
-      nodes: search.nodesExpanded,
-      visited: search.visitedStates,
-      durationMs,
+      reason: mapSearchReason(search.reason),
+      nodes: search.nodes,
+      durationMs: search.ms,
     };
   }
 
@@ -114,18 +148,16 @@ export async function testLevel(level: LevelT): Promise<TestLevelResult> {
   if (!simulation.ok) {
     return {
       ok: false,
-      reason: simulation.reason ?? 'no_path',
-      nodes: search.nodesExpanded,
-      visited: search.visitedStates,
-      durationMs,
+      reason: 'no_path',
+      nodes: search.nodes,
+      durationMs: search.ms,
     };
   }
 
   return {
     ok: true,
-    path,
-    nodes: search.nodesExpanded,
-    visited: search.visitedStates,
-    durationMs,
+    path: simulation.path.length > 0 ? simulation.path : path,
+    nodes: search.nodes,
+    durationMs: search.ms,
   };
 }


### PR DESCRIPTION
## Summary
- ensure the playtester service loads dotenv before other imports and validates the OpenAI API key once workers are running
- add lazy OpenAI/Redis client initialisation for the generator and close Redis connections safely on shutdown
- replace the arcade simulator and search logic with a 60Hz physics model plus A* pathfinder, wiring results into the tester and queue logging

## Testing
- pnpm --filter playtester build

------
https://chatgpt.com/codex/tasks/task_e_68de4af1e1d8832d9f67a0af3e731116