### PR TITLE
Add auto-tuning for failing levels and persist patches

### DIFF
--- a/services/playtester/src/internal-client.ts
+++ b/services/playtester/src/internal-client.ts
@@ -70,6 +70,8 @@ export async function updateJobStatus(params: {
   status: z.infer<typeof JobStatusSchema>;
   error?: string;
   levelId?: string;
+  attempts?: number;
+  lastReason?: string;
 }): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/internal/jobs/${params.id}/status`, {
     method: 'POST',
@@ -81,6 +83,8 @@ export async function updateJobStatus(params: {
       status: JobStatusSchema.parse(params.status),
       error: params.error ?? null,
       levelId: params.levelId,
+      attempts: typeof params.attempts === 'number' ? params.attempts : undefined,
+      lastReason: params.lastReason,
     }),
   });
 
@@ -122,5 +126,31 @@ export async function submitLevelPath(params: { levelId: string; path: InputCmd[
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`Failed to submit level path: ${response.status} ${text}`);
+  }
+}
+
+export async function submitLevelPatch(params: {
+  levelId: string;
+  patch: unknown;
+  reason: string;
+  level: LevelT;
+}): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/internal/levels/patch`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({
+      level_id: params.levelId,
+      patch: params.patch,
+      reason: params.reason,
+      level: Level.parse(params.level),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to submit level patch: ${response.status} ${text}`);
   }
 }

--- a/services/playtester/src/sim/search.ts
+++ b/services/playtester/src/sim/search.ts
@@ -187,8 +187,8 @@ function advance(level: LevelT, context: ReturnType<typeof createStepContext>, s
   for (let i = 0; i < ACTION_FRAMES; i += 1) {
     const { state: next, collidedHazard } = step(level, current, input, context);
     current = next;
-    hazard ||= collidedHazard;
-    if (hazard) {
+    if (collidedHazard) {
+      hazard = true;
       break;
     }
   }

--- a/services/playtester/src/tester.ts
+++ b/services/playtester/src/tester.ts
@@ -7,10 +7,46 @@ const WALKABLE_TILE_TYPES: LevelT['tiles'][number]['type'][] = ['ground', 'platf
 const SAFETY_GAP_PX = 16;
 const MIN_PLATFORM_WIDTH = 48;
 
-interface PrecheckResult {
-  ok: boolean;
-  reason?: string;
+export type FailReason =
+  | 'gap_too_wide'
+  | 'hazard_no_window'
+  | 'enemy_unavoidable'
+  | 'no_spawn'
+  | 'no_path'
+  | 'timeout';
+
+export interface GapDetail {
+  prevIndex: number | null;
+  nextIndex: number | null;
+  fromX: number;
+  toX: number;
+  gap: number;
+  maxGapPx?: number;
+  y: number;
 }
+
+export interface HazardDetail {
+  tileIndex: number;
+  tile: LevelT['tiles'][number];
+}
+
+export interface Fail {
+  ok: false;
+  reason: FailReason;
+  at?: { x: number; y: number };
+  details?: unknown;
+}
+
+interface PrecheckResult {
+  ok: true;
+}
+
+interface PrecheckFailure {
+  ok: false;
+  fail: Fail;
+}
+
+type PrecheckOutcome = PrecheckResult | PrecheckFailure;
 
 function defaultInputState(): InputState {
   return { left: false, right: false, jump: false, fly: false, thrust: false };
@@ -65,41 +101,141 @@ function compressPath(commands: InputCmd[]): InputCmd[] {
   return result;
 }
 
-function runPrechecks(level: LevelT): PrecheckResult {
+function mapWalkable(level: LevelT) {
+  return level.tiles
+    .map((tile, index) => ({ tile, index }))
+    .filter((entry) => WALKABLE_TILE_TYPES.includes(entry.tile.type))
+    .sort((a, b) => a.tile.x - b.tile.x);
+}
+
+function findLargestGap(level: LevelT, maxGapPx: number): GapDetail | null {
+  const walkable = mapWalkable(level);
+  let widest: GapDetail | null = null;
+  for (let i = 0; i < walkable.length - 1; i += 1) {
+    const current = walkable[i];
+    const next = walkable[i + 1];
+    const gap = next.tile.x - (current.tile.x + current.tile.w);
+    if (gap <= 0) {
+      continue;
+    }
+    if (!widest || gap > widest.gap) {
+      widest = {
+        prevIndex: current.index,
+        nextIndex: next.index,
+        fromX: current.tile.x + current.tile.w,
+        toX: next.tile.x,
+        gap,
+        maxGapPx,
+        y: current.tile.y,
+      };
+    }
+  }
+  return widest;
+}
+
+function runPrechecks(level: LevelT): PrecheckOutcome {
   const spawn = createSpawn(level);
   if (!spawn) {
-    return { ok: false, reason: 'no_spawn' };
+    return {
+      ok: false,
+      fail: {
+        ok: false,
+        reason: 'no_spawn',
+        at: { x: 0, y: level.exit.y },
+        details: { message: 'no_valid_spawn' },
+      },
+    };
   }
 
   if (level.exit.x <= spawn.x) {
-    return { ok: false, reason: 'no_path' };
+    return {
+      ok: false,
+      fail: {
+        ok: false,
+        reason: 'no_path',
+        at: { x: level.exit.x, y: level.exit.y },
+        details: { spawnX: spawn.x },
+      },
+    };
   }
 
-  const walkable = level.tiles.filter((tile) => WALKABLE_TILE_TYPES.includes(tile.type));
-  if (walkable.some((tile) => tile.w < MIN_PLATFORM_WIDTH)) {
-    return { ok: false, reason: 'gap_too_wide' };
+  const walkable = level.tiles
+    .map((tile, index) => ({ tile, index }))
+    .filter((entry) => WALKABLE_TILE_TYPES.includes(entry.tile.type));
+
+  for (const entry of walkable) {
+    if (entry.tile.w < MIN_PLATFORM_WIDTH) {
+      return {
+        ok: false,
+        fail: {
+          ok: false,
+          reason: 'gap_too_wide',
+          at: { x: entry.tile.x, y: entry.tile.y },
+          details: {
+            tileIndex: entry.index,
+            tile: { ...entry.tile },
+            minWidth: MIN_PLATFORM_WIDTH,
+          },
+        },
+      };
+    }
   }
 
-  const sorted = [...walkable].sort((a, b) => a.x - b.x);
+  const sorted = [...walkable].sort((a, b) => a.tile.x - b.tile.x);
   const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + SAFETY_GAP_PX;
   for (let i = 0; i < sorted.length - 1; i += 1) {
     const current = sorted[i];
     const next = sorted[i + 1];
-    const gap = next.x - (current.x + current.w);
+    const gap = next.tile.x - (current.tile.x + current.tile.w);
     if (gap > maxGap) {
-      return { ok: false, reason: 'gap_too_wide' };
+      return {
+        ok: false,
+        fail: {
+          ok: false,
+          reason: 'gap_too_wide',
+          at: { x: current.tile.x + current.tile.w, y: current.tile.y },
+          details: {
+            gap: {
+              prevIndex: current.index,
+              nextIndex: next.index,
+              fromX: current.tile.x + current.tile.w,
+              toX: next.tile.x,
+              gap,
+              maxGapPx: maxGap,
+              y: current.tile.y,
+            } satisfies GapDetail,
+          },
+        },
+      };
     }
   }
 
-  const hazards = level.tiles.filter((tile) => tile.type === 'hazard');
+  const hazards = level.tiles
+    .map((tile, index) => ({ tile, index }))
+    .filter((entry) => entry.tile.type === 'hazard');
+
   for (const hazard of hazards) {
-    const hasWindow = walkable.some((tile) => {
-      const horizontal = tile.x < hazard.x + hazard.w && hazard.x < tile.x + tile.w;
-      const vertical = hazard.y >= tile.y - tile.h && hazard.y <= tile.y + 8;
+    const hasWindow = walkable.some((entry) => {
+      const tile = entry.tile;
+      const horizontal = tile.x < hazard.tile.x + hazard.tile.w && hazard.tile.x < tile.x + tile.w;
+      const vertical = hazard.tile.y >= tile.y - tile.h && hazard.tile.y <= tile.y + 8;
       return horizontal && vertical;
     });
     if (!hasWindow) {
-      return { ok: false, reason: 'hazard_no_window' };
+      return {
+        ok: false,
+        fail: {
+          ok: false,
+          reason: 'hazard_no_window',
+          at: { x: hazard.tile.x + hazard.tile.w / 2, y: hazard.tile.y },
+          details: {
+            hazard: {
+              tileIndex: hazard.index,
+              tile: { ...hazard.tile },
+            } satisfies HazardDetail,
+          },
+        },
+      };
     }
   }
 
@@ -109,35 +245,87 @@ function runPrechecks(level: LevelT): PrecheckResult {
 export interface TestLevelResult {
   ok: boolean;
   path?: InputCmd[];
-  reason?: string;
+  fail?: Fail;
+  reason?: FailReason;
   nodes?: number;
   durationMs?: number;
 }
 
-function mapSearchReason(reason?: string): string {
+function mapSearchFail(level: LevelT, reason?: string): Fail {
+  const maxGap = maxJumpGapPX(Boolean(level.rules.abilities.highJump)) + SAFETY_GAP_PX;
+  const closestGap = findLargestGap(level, maxGap);
+
   if (!reason) {
-    return 'no_path';
+    return {
+      ok: false,
+      reason: 'no_path',
+      at: closestGap ? { x: closestGap.fromX, y: closestGap.y } : undefined,
+      details: closestGap ? { closestGap } : undefined,
+    };
   }
+
   if (reason === 'timeout' || reason === 'node_limit') {
-    return 'timeout';
+    return {
+      ok: false,
+      reason: 'timeout',
+      at: closestGap ? { x: closestGap.fromX, y: closestGap.y } : undefined,
+      details: closestGap ? { closestGap } : undefined,
+    };
   }
+
   if (reason === 'no_spawn') {
-    return 'no_spawn';
+    return {
+      ok: false,
+      reason: 'no_spawn',
+      at: { x: 0, y: level.exit.y },
+      details: { message: 'search_no_spawn' },
+    };
   }
-  return 'no_path';
+
+  return {
+    ok: false,
+    reason: 'no_path',
+    at: closestGap ? { x: closestGap.fromX, y: closestGap.y } : undefined,
+    details: closestGap ? { closestGap } : undefined,
+  };
+}
+
+function findHazardNear(level: LevelT, point?: { x: number; y: number }) {
+  if (!point) {
+    return null;
+  }
+  const hazardEntries = level.tiles
+    .map((tile, index) => ({ tile, index }))
+    .filter((entry) => entry.tile.type === 'hazard');
+  for (const entry of hazardEntries) {
+    if (
+      point.x >= entry.tile.x &&
+      point.x <= entry.tile.x + entry.tile.w &&
+      point.y >= entry.tile.y &&
+      point.y <= entry.tile.y + entry.tile.h
+    ) {
+      return {
+        tileIndex: entry.index,
+        tile: { ...entry.tile },
+      } satisfies HazardDetail;
+    }
+  }
+  return null;
 }
 
 export async function testLevel(level: LevelT): Promise<TestLevelResult> {
   const precheck = runPrechecks(level);
   if (!precheck.ok) {
-    return { ok: false, reason: precheck.reason };
+    return { ok: false, fail: precheck.fail, reason: precheck.fail.reason };
   }
 
   const search = findPath(level, 3000, 80000);
   if (!search.ok || !search.path) {
+    const fail = mapSearchFail(level, search.reason);
     return {
       ok: false,
-      reason: mapSearchReason(search.reason),
+      fail,
+      reason: fail.reason,
       nodes: search.nodes,
       durationMs: search.ms,
     };
@@ -146,9 +334,29 @@ export async function testLevel(level: LevelT): Promise<TestLevelResult> {
   const path = compressPath(search.path);
   const simulation = simulate(level, path);
   if (!simulation.ok) {
+    if (simulation.reason === 'hazard') {
+      const failPoint = simulation.fail?.at;
+      const hazard = simulation.fail?.hazard ?? findHazardNear(level, failPoint ?? undefined);
+      const fail: Fail = {
+        ok: false,
+        reason: 'hazard_no_window',
+        at: failPoint,
+        details: hazard ? { hazard } : undefined,
+      };
+      return {
+        ok: false,
+        fail,
+        reason: fail.reason,
+        nodes: search.nodes,
+        durationMs: search.ms,
+      };
+    }
+
+    const fail = mapSearchFail(level, simulation.reason === 'timeout' ? 'timeout' : 'no_path');
     return {
       ok: false,
-      reason: 'no_path',
+      fail,
+      reason: fail.reason,
       nodes: search.nodes,
       durationMs: search.ms,
     };

--- a/services/playtester/src/tuner.ts
+++ b/services/playtester/src/tuner.ts
@@ -1,0 +1,286 @@
+import { Level, LevelT } from '@ir/game-spec';
+
+import { Fail, GapDetail, HazardDetail } from './tester';
+
+const MAX_ADJUST_PX = 48;
+const PLATFORM_WIDTH = 48;
+const HAZARD_SHIFT_Y = 8;
+const ENEMY_SPEED_SCALE = 0.8;
+const ENEMY_SHIFT_X = 24;
+
+interface TuneResult {
+  patched: LevelT;
+  patch: { op: string; info: unknown };
+}
+
+function cloneLevel(level: LevelT): LevelT {
+  return JSON.parse(JSON.stringify(level)) as LevelT;
+}
+
+function finalizeLevel(level: LevelT, patch: { op: string; info: unknown }): TuneResult | null {
+  try {
+    const validated = Level.parse(level);
+    return { patched: validated, patch };
+  } catch (error) {
+    return null;
+  }
+}
+
+function extractGap(details: unknown): GapDetail | null {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+  const record = details as Record<string, unknown>;
+  if ('gap' in record && record.gap && typeof record.gap === 'object') {
+    const gap = record.gap as Record<string, unknown>;
+    if (
+      typeof gap.fromX === 'number' &&
+      typeof gap.toX === 'number' &&
+      typeof gap.gap === 'number' &&
+      typeof gap.y === 'number'
+    ) {
+      return {
+        prevIndex: typeof gap.prevIndex === 'number' ? (gap.prevIndex as number) : null,
+        nextIndex: typeof gap.nextIndex === 'number' ? (gap.nextIndex as number) : null,
+        fromX: gap.fromX,
+        toX: gap.toX,
+        gap: gap.gap,
+        maxGapPx: typeof gap.maxGapPx === 'number' ? (gap.maxGapPx as number) : undefined,
+        y: gap.y,
+      };
+    }
+  }
+  return null;
+}
+
+function extractHazard(details: unknown): HazardDetail | null {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+  const record = details as Record<string, unknown>;
+  if ('hazard' in record && record.hazard && typeof record.hazard === 'object') {
+    const hazard = record.hazard as Record<string, unknown>;
+    if (typeof hazard.tileIndex === 'number' && hazard.tile && typeof hazard.tile === 'object') {
+      const tile = hazard.tile as Record<string, unknown>;
+      if (
+        typeof tile.x === 'number' &&
+        typeof tile.y === 'number' &&
+        typeof tile.w === 'number' &&
+        typeof tile.h === 'number' &&
+        typeof tile.type === 'string'
+      ) {
+        return {
+          tileIndex: hazard.tileIndex as number,
+          tile: {
+            x: tile.x,
+            y: tile.y,
+            w: tile.w,
+            h: tile.h,
+            type: tile.type as LevelT['tiles'][number]['type'],
+          },
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function adjustGap(level: LevelT, fail: Fail): TuneResult | null {
+  const gapDetail = extractGap(fail.details);
+  const patched = cloneLevel(level);
+
+  if (gapDetail) {
+    const prevIndex = gapDetail.prevIndex ?? null;
+    const nextIndex = gapDetail.nextIndex ?? null;
+    const previousTile = prevIndex !== null ? { ...patched.tiles[prevIndex] } : null;
+    const targetGap = Math.max((gapDetail.maxGapPx ?? gapDetail.gap) - 16, 0);
+    const reduce = Math.min(Math.max(gapDetail.gap - targetGap, 0), MAX_ADJUST_PX, gapDetail.gap);
+
+    if (previousTile && reduce > 0) {
+      previousTile.w += reduce;
+      patched.tiles[prevIndex!] = previousTile;
+      return finalizeLevel(patched, {
+        op: 'extend_tile',
+        info: { tileIndex: prevIndex, deltaW: reduce },
+      });
+    }
+
+    const neighborIndex = prevIndex ?? nextIndex;
+    const neighbor = neighborIndex !== null ? patched.tiles[neighborIndex] : undefined;
+    const height = neighbor ? neighbor.h : 16;
+    const gapCenter = gapDetail.fromX + gapDetail.gap / 2;
+    const platformX = Math.round(gapCenter - PLATFORM_WIDTH / 2);
+    const newTile: LevelT['tiles'][number] = {
+      x: platformX,
+      y: gapDetail.y,
+      w: PLATFORM_WIDTH,
+      h: height,
+      type: 'platform',
+    };
+    patched.tiles.push(newTile);
+    return finalizeLevel(patched, {
+      op: 'add_platform',
+      info: { tile: newTile, gap: gapDetail },
+    });
+  }
+
+  if (fail.at) {
+    const newTile: LevelT['tiles'][number] = {
+      x: Math.round(fail.at.x - PLATFORM_WIDTH / 2),
+      y: fail.at.y,
+      w: PLATFORM_WIDTH,
+      h: 16,
+      type: 'platform',
+    };
+    patched.tiles.push(newTile);
+    return finalizeLevel(patched, {
+      op: 'add_platform',
+      info: { tile: newTile },
+    });
+  }
+
+  return null;
+}
+
+function adjustHazard(level: LevelT, fail: Fail): TuneResult | null {
+  const patched = cloneLevel(level);
+  const hazard = extractHazard(fail.details);
+
+  if (hazard && patched.tiles[hazard.tileIndex]?.type === 'hazard') {
+    const tile = { ...patched.tiles[hazard.tileIndex] };
+    tile.y += Math.min(HAZARD_SHIFT_Y, MAX_ADJUST_PX);
+    patched.tiles[hazard.tileIndex] = tile;
+    return finalizeLevel(patched, {
+      op: 'shift_hazard',
+      info: { tileIndex: hazard.tileIndex, deltaY: Math.min(HAZARD_SHIFT_Y, MAX_ADJUST_PX) },
+    });
+  }
+
+  if (fail.at) {
+    const movingIndex = patched.moving?.findIndex((platform) => {
+      const [fx, fy] = platform.from;
+      const [tx, ty] = platform.to;
+      const dx1 = fail.at!.x - fx;
+      const dy1 = fail.at!.y - fy;
+      const dx2 = fail.at!.x - tx;
+      const dy2 = fail.at!.y - ty;
+      const dist = Math.min(Math.hypot(dx1, dy1), Math.hypot(dx2, dy2));
+      return dist <= 64;
+    });
+    if (movingIndex !== undefined && movingIndex >= 0) {
+      const moving = { ...patched.moving[movingIndex] };
+      moving.period_ms += 200;
+      patched.moving[movingIndex] = moving;
+      return finalizeLevel(patched, {
+        op: 'extend_period',
+        info: { movingIndex, period_ms: moving.period_ms },
+      });
+    }
+  }
+
+  return null;
+}
+
+function adjustEnemy(level: LevelT, fail: Fail): TuneResult | null {
+  const patched = cloneLevel(level);
+  const details = (fail.details ?? {}) as Record<string, unknown>;
+  let enemyIndex: number | null = null;
+  if (typeof details.enemyIndex === 'number') {
+    enemyIndex = details.enemyIndex;
+  } else if (fail.at) {
+    const candidate = patched.enemies.findIndex((enemy) => Math.hypot(enemy.x - fail.at!.x, enemy.y - fail.at!.y) <= 96);
+    if (candidate >= 0) {
+      enemyIndex = candidate;
+    }
+  }
+
+  if (enemyIndex === null || enemyIndex < 0 || enemyIndex >= patched.enemies.length) {
+    return null;
+  }
+
+  const enemy = { ...patched.enemies[enemyIndex] };
+  const scaled = enemy.speed * ENEMY_SPEED_SCALE;
+  if (scaled >= enemy.speed * 0.99) {
+    enemy.x -= ENEMY_SHIFT_X;
+    patched.enemies[enemyIndex] = enemy;
+    return finalizeLevel(patched, {
+      op: 'shift_enemy_spawn',
+      info: { enemyIndex, deltaX: -ENEMY_SHIFT_X },
+    });
+  }
+
+  enemy.speed = Math.max(10, scaled);
+  patched.enemies[enemyIndex] = enemy;
+  return finalizeLevel(patched, {
+    op: 'slow_enemy',
+    info: { enemyIndex, speed: enemy.speed },
+  });
+}
+
+function ensureClosestGap(fail: Fail): GapDetail | null {
+  const gap = extractGap(fail.details);
+  if (gap) {
+    return gap;
+  }
+  if (fail.details && typeof fail.details === 'object') {
+    const record = fail.details as Record<string, unknown>;
+    if (record.closestGap && typeof record.closestGap === 'object') {
+      return extractGap({ gap: record.closestGap });
+    }
+  }
+  return null;
+}
+
+function addHelperPlatform(level: LevelT, fail: Fail): TuneResult | null {
+  const patched = cloneLevel(level);
+  const gap = ensureClosestGap(fail);
+  const y = gap?.y ?? fail.at?.y ?? level.exit.y;
+  const x = gap ? gap.fromX + Math.max((gap.gap - PLATFORM_WIDTH) / 2, -PLATFORM_WIDTH / 2) : fail.at?.x ?? level.exit.x - PLATFORM_WIDTH;
+  const tile: LevelT['tiles'][number] = {
+    x: Math.round(x),
+    y,
+    w: PLATFORM_WIDTH,
+    h: 16,
+    type: 'platform',
+  };
+  patched.tiles.push(tile);
+  return finalizeLevel(patched, {
+    op: 'add_helper_platform',
+    info: { tile, gap },
+  });
+}
+
+function addSpawnPlatform(level: LevelT, fail: Fail): TuneResult | null {
+  const patched = cloneLevel(level);
+  const groundY = fail.at?.y ?? level.exit.y;
+  const tile: LevelT['tiles'][number] = {
+    x: 0,
+    y: groundY,
+    w: 96,
+    h: 16,
+    type: 'ground',
+  };
+  patched.tiles.push(tile);
+  return finalizeLevel(patched, {
+    op: 'add_spawn_platform',
+    info: { tile },
+  });
+}
+
+export function tune(level: LevelT, fail: Fail): TuneResult | null {
+  switch (fail.reason) {
+    case 'gap_too_wide':
+      return adjustGap(level, fail);
+    case 'hazard_no_window':
+      return adjustHazard(level, fail);
+    case 'enemy_unavoidable':
+      return adjustEnemy(level, fail);
+    case 'no_spawn':
+      return addSpawnPlatform(level, fail);
+    case 'no_path':
+    case 'timeout':
+      return addHelperPlatform(level, fail);
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- enrich playtester failure reporting, add tuning heuristics, and loop retests up to three rounds
- track job attempts and last failure reasons while persisting applied patches as level revisions
- expose revision listings and patch ingestion endpoints in the API for updated worker interactions

## Testing
- pnpm --filter @srv/playtester build
- pnpm --filter api build

------
https://chatgpt.com/codex/tasks/task_e_68de64ef85e0832db4e0bb7c43687b48