### PR TITLE
Add ghost replay, new scenes, and approved level feed

### DIFF
--- a/apps/web/src/game/Ghost.ts
+++ b/apps/web/src/game/Ghost.ts
@@ -1,0 +1,150 @@
+import Phaser from 'phaser';
+
+import { RUNNER_CONSTANTS } from '../types/game';
+import type { InputCmd } from '../level/loader';
+
+type GhostSprite = Phaser.Physics.Arcade.Sprite & {
+  body: Phaser.Physics.Arcade.Body;
+};
+
+interface GhostState {
+  left: boolean;
+  right: boolean;
+  jump: boolean;
+  fly: boolean;
+  thrust: boolean;
+}
+
+export interface GhostPlayback {
+  sprite: GhostSprite;
+  stop(): void;
+}
+
+export function playGhost(
+  scene: Phaser.Scene,
+  playerSprite: Phaser.Physics.Arcade.Sprite,
+  path: InputCmd[] | null,
+): GhostPlayback | null {
+  if (!Array.isArray(path) || path.length === 0) {
+    return null;
+  }
+
+  const commands = [...path].sort((a, b) => a.t - b.t);
+  const ghost = scene.physics.add.sprite(
+    playerSprite.x,
+    playerSprite.y,
+    playerSprite.texture.key,
+  ) as GhostSprite;
+
+  ghost.setDepth(Math.max(0, playerSprite.depth - 1));
+  ghost.setAlpha(0.4);
+  ghost.setTint(0xffffff);
+  ghost.setCollideWorldBounds(true);
+  ghost.body.allowGravity = true;
+  ghost.body.setAllowGravity(true);
+  ghost.body.setImmovable(false);
+  ghost.body.checkCollision.up = true;
+  ghost.body.checkCollision.down = true;
+  ghost.body.checkCollision.left = true;
+  ghost.body.checkCollision.right = true;
+
+  const playerBody = playerSprite.body as Phaser.Physics.Arcade.Body | null;
+  if (playerBody) {
+    ghost.body.setSize(playerBody.width, playerBody.height);
+    ghost.body.setOffset(playerBody.offset.x, playerBody.offset.y);
+  }
+
+  const state: GhostState = {
+    left: false,
+    right: false,
+    jump: false,
+    fly: false,
+    thrust: false,
+  };
+
+  let timer: Phaser.Time.TimerEvent | null = null;
+  let tick = 0;
+  let commandIndex = 0;
+  let wasJumping = false;
+  const lastTick = commands[commands.length - 1]?.t ?? 0;
+
+  const applyState = () => {
+    const body = ghost.body;
+    if (!body) {
+      return;
+    }
+
+    if (state.left && !state.right) {
+      body.setVelocityX(-RUNNER_CONSTANTS.moveSpeed);
+      ghost.setFlipX(true);
+    } else if (state.right && !state.left) {
+      body.setVelocityX(RUNNER_CONSTANTS.moveSpeed);
+      ghost.setFlipX(false);
+    } else {
+      body.setVelocityX(0);
+    }
+
+    const wantsJump = state.jump || state.fly || state.thrust;
+    const grounded = body.blocked.down || body.touching.down;
+    if (wantsJump && grounded && !wasJumping) {
+      body.setVelocityY(RUNNER_CONSTANTS.jumpVelocity);
+    }
+    wasJumping = wantsJump;
+  };
+
+  const step = () => {
+    while (commandIndex < commands.length && commands[commandIndex].t <= tick) {
+      const command = commands[commandIndex];
+      if (typeof command.left === 'boolean') {
+        state.left = command.left;
+      }
+      if (typeof command.right === 'boolean') {
+        state.right = command.right;
+      }
+      if (typeof command.jump === 'boolean') {
+        state.jump = command.jump;
+      }
+      if (typeof command.fly === 'boolean') {
+        state.fly = command.fly;
+      }
+      if (typeof command.thrust === 'boolean') {
+        state.thrust = command.thrust;
+      }
+      commandIndex += 1;
+    }
+
+    applyState();
+    tick += 1;
+
+    if (tick > lastTick + 120) {
+      stop();
+    }
+  };
+
+  const stop = () => {
+    if (timer) {
+      timer.remove(false);
+      timer = null;
+    }
+    if (!ghost.scene) {
+      return;
+    }
+    ghost.destroy();
+  };
+
+  scene.time.delayedCall(500, () => {
+    if (!ghost.active) {
+      return;
+    }
+    timer = scene.time.addEvent({
+      delay: 1000 / 30,
+      loop: true,
+      callback: step,
+    });
+  });
+
+  return {
+    sprite: ghost,
+    stop,
+  };
+}

--- a/apps/web/src/level/progress.ts
+++ b/apps/web/src/level/progress.ts
@@ -1,0 +1,66 @@
+export interface LevelProgress {
+  levelNumber: number;
+  levelId: string | null;
+}
+
+const STORAGE_KEY = 'ir:season1:progress';
+
+export function loadProgress(): LevelProgress | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    const parsed = JSON.parse(stored) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    const levelNumber = Number(record.levelNumber ?? record.level_number);
+    if (!Number.isFinite(levelNumber)) {
+      return null;
+    }
+
+    const levelIdValue = record.levelId ?? record.level_id;
+    const levelId = typeof levelIdValue === 'string' ? levelIdValue : null;
+
+    return {
+      levelNumber: Math.max(1, Math.round(levelNumber)),
+      levelId,
+    } satisfies LevelProgress;
+  } catch (error) {
+    console.warn('Konnte Spielfortschritt nicht laden.', error);
+    return null;
+  }
+}
+
+export function saveProgress(progress: LevelProgress): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const payload = JSON.stringify(progress);
+    window.localStorage.setItem(STORAGE_KEY, payload);
+  } catch (error) {
+    console.warn('Konnte Spielfortschritt nicht speichern.', error);
+  }
+}
+
+export function clearProgress(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('Konnte Spielfortschritt nicht zurücksetzen.', error);
+  }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -2,6 +2,8 @@ import Phaser from 'phaser';
 
 import { BootScene } from './scenes/BootScene';
 import { GameScene } from './scenes/GameScene';
+import { StartScene } from './scenes/StartScene';
+import { TransitionScene } from './scenes/TransitionScene';
 import { RUNNER_CONSTANTS } from './types/game';
 
 const config: Phaser.Types.Core.GameConfig = {
@@ -27,7 +29,7 @@ const config: Phaser.Types.Core.GameConfig = {
     forceSetTimeOut: true,
     smoothStep: true,
   },
-  scene: [BootScene, GameScene],
+  scene: [BootScene, StartScene, TransitionScene, GameScene],
 };
 
 new Phaser.Game(config);

--- a/apps/web/src/scenes/BootScene.ts
+++ b/apps/web/src/scenes/BootScene.ts
@@ -25,22 +25,6 @@ export class BootScene extends Phaser.Scene {
       graphics.destroy();
     });
 
-    const message = this.add
-      .text(this.scale.width / 2, this.scale.height / 2, 'Season-1 starten\n<SPACE> drücken', {
-        fontSize: '32px',
-        fontFamily: 'system-ui, sans-serif',
-        color: '#f8fafc',
-        align: 'center',
-      })
-      .setOrigin(0.5);
-
-    const startSeason = () => {
-      message.destroy();
-      this.scene.start('game');
-    };
-
-    this.input.keyboard.once('keydown-SPACE', startSeason);
-    this.input.keyboard.once('keydown-ENTER', startSeason);
-    this.input.once('pointerdown', startSeason);
+    this.scene.start('start');
   }
 }

--- a/apps/web/src/scenes/GameScene.ts
+++ b/apps/web/src/scenes/GameScene.ts
@@ -2,8 +2,18 @@ import Phaser from 'phaser';
 
 import { LevelT } from '@ir/game-spec';
 
+import { playGhost, type GhostPlayback } from '../game/Ghost';
+import {
+  fetchApproved,
+  fetchLevel,
+  fetchLevelPath,
+  fetchSeasonLevels,
+  type InputCmd,
+  type LevelSummary,
+  type SeasonLevelEntry,
+} from '../level/loader';
+import { clearProgress, saveProgress } from '../level/progress';
 import { RUNNER_CONSTANTS } from '../types/game';
-import { fetchLevel, fetchSeasonLevels, type SeasonLevelEntry } from '../level/loader';
 
 const DEFAULT_WORLD_HEIGHT = 720;
 const EXIT_WIDTH = 40;
@@ -18,29 +28,58 @@ type DynamicSprite = Phaser.Physics.Arcade.Sprite & {
   body: Phaser.Physics.Arcade.Body;
 };
 
-export class GameScene extends Phaser.Scene {
-  private levelData!: LevelT;
-  private worldWidth = 0;
-  private worldHeight = DEFAULT_WORLD_HEIGHT;
+interface LevelTarget {
+  levelNumber: number;
+  levelId: string;
+  title: string;
+}
 
+export interface GameSceneParams {
+  levelNumber?: number;
+  levelId?: string | null;
+  seasonId?: string;
+}
+
+export class GameScene extends Phaser.Scene {
   private seasonId = 'season-1';
   private totalLevels = 100;
   private currentLevelNumber = 1;
   private currentLevelId: string | null = null;
-  private cachedSeasonLevels: SeasonLevelEntry[] = [];
+  private currentLevelTitle = '';
+
+  private levelData!: LevelT;
+  private worldWidth = 0;
+  private worldHeight = DEFAULT_WORLD_HEIGHT;
+
+  private seasonEntries: SeasonLevelEntry[] = [];
+  private approvedLevels: LevelSummary[] = [];
+  private preloadedLevels = new Map<string, LevelT>();
+  private pendingNextLevel: LevelTarget | null = null;
 
   private player!: DynamicSprite;
   private platforms!: Phaser.Physics.Arcade.StaticGroup;
   private hazards!: Phaser.Physics.Arcade.StaticGroup;
   private exitZone!: StaticSprite;
 
-  private hudText!: Phaser.GameObjects.Text;
-  private pauseOverlay!: Phaser.GameObjects.Text;
+  private platformCollider: Phaser.Physics.Arcade.Collider | null = null;
+  private hazardOverlap: Phaser.Physics.Arcade.Collider | null = null;
+  private exitOverlap: Phaser.Physics.Arcade.Collider | null = null;
+
+  private ghostPlayback: GhostPlayback | null = null;
+  private ghostCollider: Phaser.Physics.Arcade.Collider | null = null;
+
+  private hudLevelText!: Phaser.GameObjects.Text;
+  private hudTimerText!: Phaser.GameObjects.Text;
+  private hudAbilitiesText!: Phaser.GameObjects.Text;
+  private hudRetryText!: Phaser.GameObjects.Text;
+  private loadingText!: Phaser.GameObjects.Text;
+  private pauseOverlay!: Phaser.GameObjects.Container;
 
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private keyA!: Phaser.Input.Keyboard.Key;
   private keyD!: Phaser.Input.Keyboard.Key;
   private spaceKey!: Phaser.Input.Keyboard.Key;
+  private keyR!: Phaser.Input.Keyboard.Key;
   private pauseKey!: Phaser.Input.Keyboard.Key;
   private jumpKeys: Phaser.Input.Keyboard.Key[] = [];
 
@@ -57,36 +96,42 @@ export class GameScene extends Phaser.Scene {
     super('game');
   }
 
-  create(): void {
-    this.isLevelReady = false;
-    void this.initializeLevel();
+  init(data: GameSceneParams): void {
+    if (typeof data.seasonId === 'string' && data.seasonId.length > 0) {
+      this.seasonId = data.seasonId;
+    }
+
+    if (typeof data.levelNumber === 'number' && Number.isFinite(data.levelNumber)) {
+      this.currentLevelNumber = Math.max(1, Math.round(data.levelNumber));
+    }
+
+    if (typeof data.levelId === 'string') {
+      this.currentLevelId = data.levelId;
+    } else if (data.levelId === null) {
+      this.currentLevelId = null;
+    }
   }
 
-  private async initializeLevel(): Promise<void> {
-    try {
-      const level = await this.loadLevelFor(this.currentLevelNumber);
-      this.levelData = level;
-      this.currentLevelId = level.id;
+  create(): void {
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.dispose, this);
+    this.events.once(Phaser.Scenes.Events.DESTROY, this.dispose, this);
 
-      this.setupInput();
-      this.setupLevel();
-      this.setupPlayer();
-      this.setupCamera();
-      this.setupHud();
+    this.setupInput();
+    this.createHud();
+    this.createPauseMenu();
 
-      this.levelStartTime = this.time.now;
-      this.pauseStartedAt = 0;
-      this.accumulatedPauseTime = 0;
-      this.isPaused = false;
-      this.isLevelReady = true;
-    } catch (error) {
-      console.error('Level konnte nicht geladen werden:', error);
-      this.isLevelReady = false;
-    }
+    this.physics.world.setBoundsCollision(true, true, true, false);
+
+    void this.initializeLevel();
   }
 
   update(time: number): void {
     if (!this.isLevelReady) {
+      return;
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.keyR)) {
+      this.restartLevel();
       return;
     }
 
@@ -101,11 +146,198 @@ export class GameScene extends Phaser.Scene {
     this.checkFailState();
   }
 
+  private async initializeLevel(): Promise<void> {
+    this.isLevelReady = false;
+    this.showLoadingState(true);
+    this.disposeLevelObjects();
+
+    try {
+      const target = await this.resolveCurrentLevelTarget();
+      this.currentLevelNumber = target.levelNumber;
+      const level = await this.obtainLevel(target.levelId);
+      this.levelData = level;
+      this.currentLevelId = target.levelId;
+      this.currentLevelTitle = target.title;
+
+      this.setupLevel();
+      this.setupPlayer();
+      this.setupCamera();
+
+      this.levelStartTime = this.time.now;
+      this.pauseStartedAt = 0;
+      this.accumulatedPauseTime = 0;
+      this.isPaused = false;
+      this.isLevelReady = true;
+
+      const ghostPromise = fetchLevelPath(level.id);
+      void this.prefetchNextLevel(target.levelNumber);
+
+      const path = await ghostPromise;
+      this.startGhost(path);
+    } catch (error) {
+      console.error('Level konnte nicht geladen werden:', error);
+      this.isLevelReady = false;
+    } finally {
+      this.showLoadingState(false);
+    }
+  }
+
+  private dispose(): void {
+    this.disposeLevelObjects();
+    this.preloadedLevels.clear();
+  }
+
+  private disposeLevelObjects(): void {
+    this.stopGhost();
+
+    if (this.platformCollider) {
+      this.platformCollider.destroy();
+      this.platformCollider = null;
+    }
+
+    if (this.hazardOverlap) {
+      this.hazardOverlap.destroy();
+      this.hazardOverlap = null;
+    }
+
+    if (this.exitOverlap) {
+      this.exitOverlap.destroy();
+      this.exitOverlap = null;
+    }
+
+    if (this.ghostCollider) {
+      this.ghostCollider.destroy();
+      this.ghostCollider = null;
+    }
+
+    if (this.player) {
+      this.player.destroy();
+    }
+
+    if (this.platforms) {
+      this.platforms.clear(true, true);
+      this.platforms.destroy(true);
+    }
+
+    if (this.hazards) {
+      this.hazards.clear(true, true);
+      this.hazards.destroy(true);
+    }
+
+    if (this.exitZone) {
+      this.exitZone.destroy();
+    }
+  }
+
+  private async resolveCurrentLevelTarget(): Promise<LevelTarget> {
+    await this.ensureCatalogs();
+    const desiredNumber = Math.max(1, this.currentLevelNumber);
+
+    if (this.currentLevelId) {
+      const title = this.findTitleForLevel(this.currentLevelId) ?? `Level ${desiredNumber}`;
+      return { levelNumber: desiredNumber, levelId: this.currentLevelId, title };
+    }
+
+    const candidate = await this.resolveLevelTargetForNumber(desiredNumber);
+    if (candidate) {
+      return candidate;
+    }
+
+    return {
+      levelNumber: desiredNumber,
+      levelId: 'demo-01',
+      title: 'Demo Level',
+    };
+  }
+
+  private async resolveLevelTargetForNumber(levelNumber: number): Promise<LevelTarget | null> {
+    await this.ensureCatalogs();
+
+    const seasonCandidate = this.seasonEntries.find(
+      (entry) => entry.levelNumber === levelNumber && typeof entry.levelId === 'string',
+    );
+    if (seasonCandidate?.levelId) {
+      return {
+        levelNumber,
+        levelId: seasonCandidate.levelId,
+        title: `Level ${seasonCandidate.levelNumber}`,
+      };
+    }
+
+    const approvedCandidate = this.approvedLevels[levelNumber - 1] ?? this.approvedLevels[0];
+    if (approvedCandidate) {
+      return {
+        levelNumber,
+        levelId: approvedCandidate.id,
+        title: approvedCandidate.title,
+      };
+    }
+
+    return null;
+  }
+
+  private async ensureCatalogs(): Promise<void> {
+    if (this.seasonEntries.length === 0) {
+      const published = await fetchSeasonLevels(this.seasonId, { published: true });
+      if (published.length > 0) {
+        this.seasonEntries = published;
+      }
+    }
+
+    if (this.approvedLevels.length === 0) {
+      const approved = await fetchApproved({ limit: 100, offset: 0 });
+      this.approvedLevels = approved;
+    }
+  }
+
+  private findTitleForLevel(levelId: string): string | null {
+    const approved = this.approvedLevels.find((entry) => entry.id === levelId);
+    if (approved) {
+      return approved.title;
+    }
+    return null;
+  }
+
+  private async obtainLevel(levelId: string): Promise<LevelT> {
+    const cached = this.preloadedLevels.get(levelId);
+    if (cached) {
+      return cached;
+    }
+
+    const level = await fetchLevel(levelId);
+    this.preloadedLevels.set(levelId, level);
+    this.preloadedLevels.set(level.id, level);
+    return level;
+  }
+
+  private async prefetchNextLevel(currentNumber: number): Promise<void> {
+    const nextNumber = currentNumber + 1;
+    const candidate = await this.resolveLevelTargetForNumber(nextNumber);
+    if (!candidate) {
+      this.pendingNextLevel = null;
+      return;
+    }
+
+    this.pendingNextLevel = candidate;
+    if (this.preloadedLevels.has(candidate.levelId)) {
+      return;
+    }
+
+    try {
+      const level = await fetchLevel(candidate.levelId);
+      this.preloadedLevels.set(candidate.levelId, level);
+      this.preloadedLevels.set(level.id, level);
+    } catch (error) {
+      console.warn('Konnte nächstes Level nicht vorladen.', error);
+    }
+  }
+
   private setupInput(): void {
     this.cursors = this.input.keyboard.createCursorKeys();
     this.keyA = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.A);
     this.keyD = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D);
     this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    this.keyR = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R);
     this.pauseKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
 
     const maybeKeys: Array<Phaser.Input.Keyboard.Key | undefined> = [
@@ -122,7 +354,6 @@ export class GameScene extends Phaser.Scene {
     this.worldHeight = height;
 
     this.physics.world.setBounds(0, 0, width, height);
-    this.physics.world.setBoundsCollision(true, true, true, false);
 
     this.platforms = this.physics.add.staticGroup();
     this.hazards = this.physics.add.staticGroup();
@@ -167,9 +398,15 @@ export class GameScene extends Phaser.Scene {
 
     this.player = player as DynamicSprite;
 
-    this.physics.add.collider(this.player, this.platforms);
-    this.physics.add.overlap(this.player, this.hazards, () => this.restartLevel(), undefined, this);
-    this.physics.add.overlap(
+    this.platformCollider = this.physics.add.collider(this.player, this.platforms);
+    this.hazardOverlap = this.physics.add.overlap(
+      this.player,
+      this.hazards,
+      () => this.restartLevel(),
+      undefined,
+      this,
+    );
+    this.exitOverlap = this.physics.add.overlap(
       this.player,
       this.exitZone,
       () => this.completeLevel(),
@@ -187,52 +424,31 @@ export class GameScene extends Phaser.Scene {
     camera.setRoundPixels(true);
   }
 
-  private async loadLevelFor(levelNumber: number): Promise<LevelT> {
-    const entry = await this.findSeasonEntry(levelNumber);
-    if (entry?.levelId) {
-      return fetchLevel(entry.levelId);
-    }
-    return fetchLevel('demo');
-  }
-
-  private async findSeasonEntry(levelNumber: number): Promise<SeasonLevelEntry | null> {
-    const unpublished = await fetchSeasonLevels(this.seasonId, { published: false });
-    this.cachedSeasonLevels = unpublished;
-    const direct = unpublished.find(
-      (candidate) => candidate.levelNumber === levelNumber && typeof candidate.levelId === 'string',
-    );
-    if (direct) {
-      return direct;
+  private startGhost(path: InputCmd[] | null): void {
+    this.stopGhost();
+    if (!path || path.length === 0) {
+      return;
     }
 
-    const published = await fetchSeasonLevels(this.seasonId, { published: true });
-    this.cachedSeasonLevels = published;
-    const fallback = published.find(
-      (candidate) => candidate.levelNumber === levelNumber && typeof candidate.levelId === 'string',
-    );
-    return fallback ?? null;
+    const playback = playGhost(this, this.player, path);
+    if (!playback) {
+      return;
+    }
+
+    this.ghostPlayback = playback;
+    this.ghostCollider = this.physics.add.collider(playback.sprite, this.platforms);
   }
 
-  private setupHud(): void {
-    this.hudText = this.add
-      .text(16, 16, '', {
-        fontSize: '20px',
-        fontFamily: 'system-ui, sans-serif',
-        color: '#f8fafc',
-      })
-      .setScrollFactor(0)
-      .setDepth(100);
+  private stopGhost(): void {
+    if (this.ghostCollider) {
+      this.ghostCollider.destroy();
+      this.ghostCollider = null;
+    }
 
-    this.pauseOverlay = this.add
-      .text(this.scale.width / 2, this.scale.height / 2, 'PAUSE', {
-        fontSize: '48px',
-        fontFamily: 'system-ui, sans-serif',
-        color: '#f8fafc',
-      })
-      .setOrigin(0.5)
-      .setScrollFactor(0)
-      .setDepth(200)
-      .setVisible(false);
+    if (this.ghostPlayback) {
+      this.ghostPlayback.stop();
+      this.ghostPlayback = null;
+    }
   }
 
   private processMovement(time: number): void {
@@ -287,46 +503,191 @@ export class GameScene extends Phaser.Scene {
   }
 
   private restartLevel(): void {
+    if (!this.scene.isActive()) {
+      return;
+    }
+
     this.isLevelReady = false;
-    this.cachedSeasonLevels = [];
-    this.scene.restart();
+    this.pendingNextLevel = null;
+    this.scene.restart({
+      seasonId: this.seasonId,
+      levelNumber: this.currentLevelNumber,
+      levelId: this.currentLevelId,
+    });
   }
 
   private completeLevel(): void {
     const elapsed = this.getElapsedSeconds(this.time.now);
     console.info(`Level geschafft in ${elapsed.toFixed(2)}s`);
     this.isLevelReady = false;
-    if (this.currentLevelNumber < this.totalLevels) {
-      this.currentLevelNumber += 1;
+
+    const next = this.pendingNextLevel;
+    if (next) {
+      saveProgress({ levelNumber: next.levelNumber, levelId: next.levelId });
+      this.scene.launch('transition', {
+        from: 'game',
+        target: 'game',
+        payload: {
+          seasonId: this.seasonId,
+          levelNumber: next.levelNumber,
+          levelId: next.levelId,
+        } satisfies GameSceneParams,
+      });
+    } else {
+      clearProgress();
+      this.scene.launch('transition', {
+        from: 'game',
+        target: 'start',
+      });
     }
-    this.currentLevelId = null;
-    this.cachedSeasonLevels = [];
-    this.scene.restart();
   }
 
   private handlePauseToggle(time: number): void {
-    if (Phaser.Input.Keyboard.JustDown(this.pauseKey)) {
-      this.isPaused = !this.isPaused;
-
-      if (this.isPaused) {
-        this.pauseStartedAt = time;
-        this.physics.world.pause();
-      } else {
-        this.accumulatedPauseTime += time - this.pauseStartedAt;
-        this.physics.world.resume();
-      }
-
-      this.pauseOverlay.setVisible(this.isPaused);
+    if (!Phaser.Input.Keyboard.JustDown(this.pauseKey)) {
+      return;
     }
+
+    this.isPaused = !this.isPaused;
+
+    if (this.isPaused) {
+      this.pauseStartedAt = time;
+      this.physics.world.pause();
+      this.pauseOverlay.setVisible(true);
+    } else {
+      this.accumulatedPauseTime += time - this.pauseStartedAt;
+      this.physics.world.resume();
+      this.pauseOverlay.setVisible(false);
+    }
+  }
+
+  private resumeGame(): void {
+    if (!this.isPaused) {
+      return;
+    }
+
+    this.isPaused = false;
+    this.physics.world.resume();
+    this.accumulatedPauseTime += this.time.now - this.pauseStartedAt;
+    this.pauseOverlay.setVisible(false);
+  }
+
+  private quitToMenu(): void {
+    this.isLevelReady = false;
+    this.physics.world.resume();
+    this.pauseOverlay.setVisible(false);
+    this.scene.launch('transition', {
+      from: 'game',
+      target: 'start',
+    });
+  }
+
+  private createHud(): void {
+    this.hudLevelText = this.add
+      .text(16, 16, '', {
+        fontSize: '18px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.hudTimerText = this.add
+      .text(this.scale.width - 16, 16, '', {
+        fontSize: '18px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(1, 0)
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.hudAbilitiesText = this.add
+      .text(16, 48, '', {
+        fontSize: '16px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#e2e8f0',
+      })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.hudRetryText = this.add
+      .text(16, this.scale.height - 32, '[R] Neustart  ·  [Esc] Pause', {
+        fontSize: '16px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#94a3b8',
+      })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.loadingText = this.add
+      .text(this.scale.width / 2, this.scale.height / 2, 'Lade Level …', {
+        fontSize: '24px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5)
+      .setScrollFactor(0)
+      .setDepth(300)
+      .setVisible(false);
+  }
+
+  private createPauseMenu(): void {
+    const width = this.scale.width;
+    const height = this.scale.height;
+
+    const background = this.add
+      .rectangle(0, 0, width, height, 0x020617, 0.85)
+      .setOrigin(0.5);
+
+    const resumeButton = this.createPauseButton('Resume', -40, () => this.resumeGame());
+    const retryButton = this.createPauseButton('Retry', 20, () => this.restartLevel());
+    const quitButton = this.createPauseButton('Quit', 80, () => this.quitToMenu());
+
+    this.pauseOverlay = this.add
+      .container(width / 2, height / 2, [background, resumeButton, retryButton, quitButton])
+      .setDepth(400)
+      .setScrollFactor(0)
+      .setVisible(false);
+  }
+
+  private createPauseButton(
+    label: string,
+    offsetY: number,
+    onClick: () => void,
+  ): Phaser.GameObjects.Text {
+    const button = this.add
+      .text(0, offsetY, label, {
+        fontSize: '24px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+        backgroundColor: '#1e293b',
+        padding: { x: 16, y: 8 },
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    button.on('pointerdown', onClick);
+    button.on('pointerover', () => button.setStyle({ backgroundColor: '#334155' }));
+    button.on('pointerout', () => button.setStyle({ backgroundColor: '#1e293b' }));
+
+    return button;
   }
 
   private updateHud(time: number): void {
     const elapsed = this.getElapsedSeconds(time);
-    const abilities = this.formatAbilities();
-    const levelLabel = this.currentLevelId ?? this.levelData.id;
-    this.hudText.setText(
-      `Level ${this.currentLevelNumber} / ${this.totalLevels}\nID: ${levelLabel}\nAbilities: ${abilities}\nTime: ${elapsed.toFixed(2)}s`,
+    this.hudLevelText.setText(
+      `${this.formatSeasonLabel()}\n${this.currentLevelTitle}`,
     );
+    this.hudTimerText.setText(`Zeit: ${elapsed.toFixed(2)}s`);
+    this.hudAbilitiesText.setText(`Abilities: ${this.formatAbilities()}`);
+  }
+
+  private formatSeasonLabel(): string {
+    return `${this.seasonId.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())} — Level ${this.currentLevelNumber}/${this.totalLevels}`;
+  }
+
+  private showLoadingState(isLoading: boolean): void {
+    this.loadingText.setVisible(isLoading);
   }
 
   private getElapsedSeconds(time: number): number {

--- a/apps/web/src/scenes/StartScene.ts
+++ b/apps/web/src/scenes/StartScene.ts
@@ -1,0 +1,230 @@
+import Phaser from 'phaser';
+
+import { fetchApproved, type LevelSummary } from '../level/loader';
+import { loadProgress, type LevelProgress } from '../level/progress';
+import type { GameSceneParams } from './GameScene';
+
+interface ButtonConfig {
+  label: string;
+  action: () => void;
+}
+
+export class StartScene extends Phaser.Scene {
+  private buttons: Phaser.GameObjects.Text[] = [];
+  private continueButton: Phaser.GameObjects.Text | null = null;
+  private approvedContainer!: Phaser.GameObjects.Container;
+  private approvedEntries: LevelSummary[] = [];
+  private progress: LevelProgress | null = null;
+
+  constructor() {
+    super('start');
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor(0x0f172a);
+    this.progress = loadProgress();
+
+    this.add
+      .text(this.scale.width / 2, 120, 'Infinite Runner — Season 1', {
+        fontSize: '42px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(this.scale.width / 2, 176, 'Trainiere & veröffentliche deine besten Runs', {
+        fontSize: '20px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#cbd5f5',
+      })
+      .setOrigin(0.5);
+
+    this.createButtons();
+    this.createApprovedFeed();
+    void this.loadApprovedLevels();
+  }
+
+  private createButtons(): void {
+    const configs: ButtonConfig[] = [
+      {
+        label: 'Play Season-1',
+        action: () => this.startGame({ seasonId: 'season-1', levelNumber: 1 }),
+      },
+      {
+        label: 'Continue',
+        action: () => this.continueProgress(),
+      },
+      {
+        label: 'Settings',
+        action: () => this.showSettingsNotice(),
+      },
+    ];
+
+    const startY = 260;
+    const spacing = 70;
+
+    configs.forEach((config, index) => {
+      const button = this.createButton(this.scale.width / 2, startY + spacing * index, config.label);
+      button.on('pointerdown', config.action);
+      this.buttons.push(button);
+
+      if (config.label === 'Continue') {
+        this.continueButton = button;
+      }
+    });
+
+    this.updateContinueState();
+  }
+
+  private createButton(x: number, y: number, label: string): Phaser.GameObjects.Text {
+    const button = this.add
+      .text(x, y, label, {
+        fontSize: '28px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#0f172a',
+        backgroundColor: '#38bdf8',
+        padding: { x: 32, y: 12 },
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    button.on('pointerover', () => {
+      if (!button.input?.enabled) {
+        return;
+      }
+      button.setStyle({ backgroundColor: '#0ea5e9', color: '#f8fafc' });
+    });
+    button.on('pointerout', () => {
+      if (!button.input?.enabled) {
+        return;
+      }
+      button.setStyle({ backgroundColor: '#38bdf8', color: '#0f172a' });
+    });
+
+    return button;
+  }
+
+  private updateContinueState(): void {
+    if (!this.continueButton) {
+      return;
+    }
+
+    const available = Boolean(this.progress);
+    this.continueButton.input?.setEnable(available);
+    this.continueButton.setAlpha(available ? 1 : 0.5);
+
+    if (!available) {
+      this.continueButton.setStyle({ backgroundColor: '#475569', color: '#cbd5f5' });
+    } else {
+      this.continueButton.setStyle({ backgroundColor: '#38bdf8', color: '#0f172a' });
+    }
+  }
+
+  private continueProgress(): void {
+    if (!this.progress) {
+      return;
+    }
+
+    this.startGame({
+      seasonId: 'season-1',
+      levelNumber: this.progress.levelNumber,
+      levelId: this.progress.levelId ?? undefined,
+    });
+  }
+
+  private showSettingsNotice(): void {
+    const notice = this.add
+      .text(this.scale.width / 2, this.scale.height - 80, 'Settings coming soon', {
+        fontSize: '18px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+        backgroundColor: '#334155',
+        padding: { x: 12, y: 8 },
+      })
+      .setOrigin(0.5)
+      .setDepth(200)
+      .setAlpha(0);
+
+    this.tweens.add({
+      targets: notice,
+      alpha: 1,
+      duration: 200,
+      yoyo: true,
+      hold: 1200,
+      onComplete: () => notice.destroy(),
+    });
+  }
+
+  private createApprovedFeed(): void {
+    const width = this.scale.width;
+    const listX = width * 0.75;
+
+    const container = this.add.container(listX, 260);
+    const title = this.add
+      .text(0, 0, 'Latest Approved', {
+        fontSize: '24px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5, 0);
+
+    container.add(title);
+    this.approvedContainer = container;
+  }
+
+  private async loadApprovedLevels(): Promise<void> {
+    const levels = await fetchApproved({ limit: 10, offset: 0 });
+    this.approvedEntries = levels;
+    this.renderApprovedFeed();
+  }
+
+  private renderApprovedFeed(): void {
+    this.approvedContainer.removeAll(true);
+
+    const title = this.add
+      .text(0, 0, 'Latest Approved', {
+        fontSize: '24px',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5, 0);
+
+    this.approvedContainer.add(title);
+
+    const spacing = 32;
+    this.approvedEntries.slice(0, 8).forEach((entry, index) => {
+      const button = this.add
+        .text(0, (index + 1) * spacing + 8, `${entry.title}`, {
+          fontSize: '18px',
+          fontFamily: 'system-ui, sans-serif',
+          color: '#cbd5f5',
+          backgroundColor: '#1e293b',
+          padding: { x: 12, y: 6 },
+        })
+        .setOrigin(0.5, 0)
+        .setInteractive({ useHandCursor: true });
+
+      button.on('pointerover', () => button.setStyle({ backgroundColor: '#334155' }));
+      button.on('pointerout', () => button.setStyle({ backgroundColor: '#1e293b' }));
+      button.on('pointerdown', () => {
+        const levelNumber = entry.levelNumber ?? 1;
+        this.startGame({
+          seasonId: entry.seasonId ?? 'season-1',
+          levelNumber,
+          levelId: entry.id,
+        });
+      });
+
+      this.approvedContainer.add(button);
+    });
+  }
+
+  private startGame(params: GameSceneParams): void {
+    this.scene.launch('transition', {
+      from: 'start',
+      target: 'game',
+      payload: params,
+    });
+  }
+}

--- a/apps/web/src/scenes/TransitionScene.ts
+++ b/apps/web/src/scenes/TransitionScene.ts
@@ -1,0 +1,38 @@
+import Phaser from 'phaser';
+
+interface TransitionData {
+  from?: string;
+  target: string;
+  payload?: unknown;
+  duration?: number;
+}
+
+export class TransitionScene extends Phaser.Scene {
+  constructor() {
+    super('transition');
+  }
+
+  create(data: TransitionData): void {
+    const { from, target, payload, duration = 220 } = data ?? {};
+    const camera = this.cameras.main;
+    camera.setBackgroundColor(0x020617);
+    camera.fadeOut(duration, 0, 0, 0);
+
+    camera.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, () => {
+      if (from && this.scene.isActive(from)) {
+        this.scene.stop(from);
+      }
+
+      if (this.scene.isActive(target)) {
+        this.scene.stop(target);
+      }
+
+      this.scene.launch(target, payload);
+      camera.fadeIn(duration, 0, 0, 0);
+    });
+
+    camera.once(Phaser.Cameras.Scene2D.Events.FADE_IN_COMPLETE, () => {
+      this.scene.stop();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- extend the web loader with approved level listings, typed ghost paths, and resilient fallbacks
- rework the in-game scene with HUD, pause menu, ghost playback, and local progress saving plus transition handling
- add a start experience that surfaces the latest approved levels and lets players continue from stored progress

## Testing
- pnpm --filter web build *(fails: local node_modules missing / vite not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de85c8a8bc832dba28013656171e51