### PR TITLE
Introduce shared logger and enhance service logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ yarn-error.log*
 
 # Logs
 logs
+.logs/
 *.pid
 *.seed
 *.pid.lock

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@fastify/cors": "^8.4.2",
     "@ir/game-spec": "workspace:^",
+    "@ir/logger": "workspace:^",
     "better-sqlite3": "^9.4.0",
     "bullmq": "^5.12.0",
     "dotenv": "^16.6.1",
@@ -31,6 +32,7 @@
     "@types/uuid": "^9.0.7",
     "nodemon": "^3.0.3",
     "tsx": "^4.7.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig, requireProdSecrets } from './config';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('config', () => {
+  it('defaults internal token in development', () => {
+    delete process.env.INTERNAL_TOKEN;
+    process.env.NODE_ENV = 'development';
+
+    const config = loadConfig();
+
+    expect(config.internalToken).toBe('dev-internal');
+    expect(() => requireProdSecrets(config)).not.toThrow();
+  });
+
+  it('requires internal token in production', () => {
+    delete process.env.INTERNAL_TOKEN;
+    process.env.NODE_ENV = 'production';
+
+    const config = loadConfig();
+
+    expect(config.internalToken).toBeUndefined();
+    expect(() => requireProdSecrets(config)).toThrowError('INTERNAL_TOKEN must be set in production');
+  });
+
+  it('respects provided internal token in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.INTERNAL_TOKEN = 'super-secret';
+
+    const config = loadConfig();
+
+    expect(config.internalToken).toBe('super-secret');
+    expect(() => requireProdSecrets(config)).not.toThrow();
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  NODE_ENV: z.string().optional(),
+  PORT: z.string().optional(),
+  HOST: z.string().optional(),
+  REDIS_URL: z.string().optional(),
+  ORIGIN_ALLOW: z.string().optional(),
+  RATE_WINDOW_MS: z.string().optional(),
+  RATE_MAX: z.string().optional(),
+  RATE_MAX_SEASON: z.string().optional(),
+  RATE_WINDOW_SEASON_MS: z.string().optional(),
+  INTERNAL_TOKEN: z.string().optional(),
+});
+
+export interface AppConfig {
+  nodeEnv: string;
+  port: number;
+  host: string;
+  redisUrl: string;
+  originAllowList: string[];
+  rateLimit: {
+    windowMs: number;
+    max: number;
+    seasonMax: number;
+    seasonWindowMs: number;
+  };
+  internalToken: string | undefined;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  const parsed = EnvSchema.parse(env);
+  const nodeEnv = parsed.NODE_ENV ?? 'development';
+  const port = Number.parseInt(parsed.PORT ?? '3000', 10);
+  const host = parsed.HOST ?? '0.0.0.0';
+  const redisUrl = parsed.REDIS_URL ?? 'redis://localhost:6379';
+  const originAllowList = (parsed.ORIGIN_ALLOW ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  const toInteger = (value: string | undefined, fallback: number): number => {
+    const parsedValue = Number.parseInt(value ?? '', 10);
+    return Number.isFinite(parsedValue) ? parsedValue : fallback;
+  };
+
+  const rateLimit = {
+    windowMs: toInteger(parsed.RATE_WINDOW_MS, 60_000),
+    max: toInteger(parsed.RATE_MAX, 30),
+    seasonMax: toInteger(parsed.RATE_MAX_SEASON, 2),
+    seasonWindowMs: toInteger(parsed.RATE_WINDOW_SEASON_MS, 600_000),
+  };
+
+  const normalizedToken = parsed.INTERNAL_TOKEN?.trim();
+  const internalToken =
+    normalizedToken && normalizedToken.length > 0
+      ? normalizedToken
+      : nodeEnv === 'production'
+        ? undefined
+        : 'dev-internal';
+
+  return {
+    nodeEnv,
+    port,
+    host,
+    redisUrl,
+    originAllowList,
+    rateLimit,
+    internalToken,
+  };
+}
+
+export function requireProdSecrets(config: AppConfig): void {
+  if (config.nodeEnv === 'production' && !config.internalToken) {
+    throw new Error('INTERNAL_TOKEN must be set in production');
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Node",
     "module": "ES2022",
     "target": "ES2022",
-    "types": ["node"],
+    "types": ["node", "vitest"],
     "noEmit": false
   },
   "include": ["src/**/*.ts"],

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index.js';

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ir/logger",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./index.ts"
+  },
+  "main": "index.ts",
+  "types": "index.ts",
+  "dependencies": {
+    "pino": "^9.4.0"
+  }
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { Writable } from 'node:stream';
+
+import pino, { multistream, type Logger as PinoLogger, type StreamEntry } from 'pino';
+
+const LOG_DIRECTORY = path.resolve(process.cwd(), '.logs');
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+class RotatingFileStream extends Writable {
+  private currentDate: string | null = null;
+
+  private destination: fs.WriteStream | null = null;
+
+  constructor(private readonly serviceName: string) {
+    super({ decodeStrings: false });
+    fs.mkdirSync(LOG_DIRECTORY, { recursive: true });
+  }
+
+  private openStream(): void {
+    const today = formatDate(new Date());
+    if (this.currentDate === today && this.destination) {
+      return;
+    }
+
+    this.currentDate = today;
+    const filePath = path.join(LOG_DIRECTORY, `${this.serviceName}-${today}.log`);
+    if (this.destination) {
+      this.destination.end();
+    }
+    this.destination = fs.createWriteStream(filePath, { flags: 'a', encoding: 'utf8' });
+  }
+
+  override _write(
+    chunk: string | Buffer,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.openStream();
+    if (!this.destination) {
+      callback(new Error('Failed to open log file destination'));
+      return;
+    }
+
+    const writable = this.destination.write(chunk, encoding);
+    if (writable) {
+      callback();
+      return;
+    }
+    this.destination.once('drain', callback);
+  }
+
+  override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+    if (this.destination) {
+      this.destination.end(() => {
+        this.destination = null;
+        callback(error);
+      });
+      return;
+    }
+    callback(error);
+  }
+}
+
+export interface BindUnhandledOptions {
+  exitOnFatal?: boolean;
+}
+
+export type Logger = PinoLogger;
+
+export function createLogger(serviceName: string): Logger {
+  const level = process.env.LOG_LEVEL ?? 'info';
+  const fileStream = new RotatingFileStream(serviceName);
+  const streams: StreamEntry[] = [
+    { stream: process.stdout },
+    { stream: fileStream },
+  ];
+
+  const baseLogger = pino(
+    {
+      level,
+      base: {
+        service: serviceName,
+        pid: process.pid,
+        hostname: os.hostname(),
+      },
+    },
+    multistream(streams),
+  );
+
+  return baseLogger;
+}
+
+export function bindUnhandled(logger: Logger, options: BindUnhandledOptions = {}): () => void {
+  const { exitOnFatal = true } = options;
+
+  const handleRejection = (reason: unknown) => {
+    logger.error({ err: reason }, 'Unhandled promise rejection');
+    if (exitOnFatal) {
+      process.exit(1);
+    }
+  };
+
+  const handleException = (error: Error) => {
+    logger.fatal({ err: error }, 'Uncaught exception');
+    if (exitOnFatal) {
+      process.exit(1);
+    }
+  };
+
+  process.on('unhandledRejection', handleRejection);
+  process.on('uncaughtException', handleException);
+
+  return () => {
+    process.off('unhandledRejection', handleRejection);
+    process.off('uncaughtException', handleException);
+  };
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/services/playtester/package.json
+++ b/services/playtester/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ir/game-spec": "workspace:^",
+    "@ir/logger": "workspace:^",
     "bullmq": "^5.12.0",
     "dotenv": "^16.4.5",
     "fast-json-stable-stringify": "^2.1.0",

--- a/services/playtester/src/tuner.test.ts
+++ b/services/playtester/src/tuner.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 
 import { LevelT } from '@ir/game-spec';
 
+import { createLogger } from '@ir/logger';
+
 import { tune } from './tuner';
 
 type PartialLevel = Partial<Omit<LevelT, 'rules'>> & {
@@ -35,6 +37,8 @@ function buildFail(details: Record<string, unknown>): Parameters<typeof tune>[1]
   } as const;
 }
 
+const logger = createLogger('tuner-test');
+
 function testAdjustsExistingWindow() {
   const level = createLevel({
     moving: [
@@ -50,7 +54,7 @@ function testAdjustsExistingWindow() {
   });
 
   const fail = buildFail({ movingIndex: 0, minOpeningMs: 180, periodRange: [800, 1600] });
-  const result = tune(level, fail);
+  const result = tune(level, fail, logger);
 
   assert.ok(result, 'expected tune() to patch level');
   assert.equal(result?.patch.op, 'widen_hazard_window');
@@ -74,7 +78,7 @@ function testInitialisesMissingWindow() {
   });
 
   const fail = buildFail({ movingIndex: 0, minOpeningMs: 260 });
-  const result = tune(level, fail);
+  const result = tune(level, fail, logger);
 
   assert.ok(result, 'expected tune() to patch level');
   const moving = result?.patched.moving?.[0];


### PR DESCRIPTION
## Summary
- replace the root README with a Windows-friendly onboarding guide covering quick start commands, Docker usage, environment files, troubleshooting, and security notes
- add the `@ir/logger` package that emits to stdout and rotating `.logs/*` files, and use it to centralize API configuration, structured request logging, and internal route authentication
- wire the logger through the playtester worker, generator, tester, and tuner so queue activity, OpenAI usage, and patching decisions are recorded with context

## Testing
- pnpm --filter api exec vitest run
- pnpm --filter @srv/playtester run build

------
https://chatgpt.com/codex/tasks/task_e_68df77e62750832d9f824cbd1b558614