### PR TITLE
fix: wait for redis ready in costguard

### DIFF
--- a/services/playtester/src/clients.ts
+++ b/services/playtester/src/clients.ts
@@ -1,13 +1,16 @@
+import { createLogger } from '@ir/logger';
 import IORedis from 'ioredis';
 import OpenAI from 'openai';
 
-import { cfg } from './config';
+import { cfg, getConfig } from './config';
 
 const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4.1-mini';
 const OPENAI_REQ_TIMEOUT_MS = Number(process.env.OPENAI_REQ_TIMEOUT_MS ?? '20000');
 
 let openaiClient: OpenAI | null = null;
 let redisClient: IORedis | null = null;
+
+const redisLogger = createLogger('playtester:redis-client');
 
 export function getOpenAIClient(): OpenAI {
   const apiKey = cfg.openaiKey;
@@ -27,13 +30,25 @@ export function getOpenAIClient(): OpenAI {
 
 export function getRedisClient(): IORedis {
   if (!redisClient) {
-    redisClient = new IORedis(cfg.redisUrl, {
-      enableOfflineQueue: false,
+    const config = getConfig();
+    redisClient = new IORedis(config.redisUrl, {
+      enableOfflineQueue: true,
       maxRetriesPerRequest: null,
+    });
+    redisClient.on('error', (err) => {
+      redisLogger.error({ err }, 'Redis client error');
     });
   }
 
   return redisClient;
+}
+
+export async function getReadyRedis(): Promise<IORedis> {
+  const client = getRedisClient();
+  if (client.status !== 'ready') {
+    await client.connect();
+  }
+  return client;
 }
 
 export function getClients(): { openai: OpenAI; redis: IORedis } {

--- a/services/playtester/src/config.ts
+++ b/services/playtester/src/config.ts
@@ -14,3 +14,7 @@ export const cfg = {
 } as const;
 
 export type Config = typeof cfg;
+
+export function getConfig(): Config {
+  return cfg;
+}

--- a/services/playtester/src/costguard.ts
+++ b/services/playtester/src/costguard.ts
@@ -1,4 +1,4 @@
-import { getRedisClient } from './clients';
+import { getReadyRedis } from './clients';
 import { cfg } from './config';
 
 export interface Usage {
@@ -35,7 +35,7 @@ function secondsUntilEndOfDay(date: Date): number {
 export async function trackAndCheck(
   usage: Usage,
 ): Promise<{ ok: boolean; remainingUsd: number }> {
-  const redis = getRedisClient();
+  const redis = await getReadyRedis();
   const now = new Date();
   const key = formatKey(now);
   const increment = calculateUsd(usage);


### PR DESCRIPTION
## Summary
- allow the shared playtester Redis client to buffer commands and log connection errors
- provide a helper that waits for the Redis connection to be ready before use
- ensure the cost guard tracks usage only after Redis is ready to avoid startup failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ef4ab6b4832d86117a98d5e5db42