### PR TITLE
feat(api): add batch level generation endpoints

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -8,11 +8,18 @@ Der API-Dienst stellt einen stabilen Kern für das Infinite-Runner-SaaS bereit. 
 - Redis-Instanz (z.B. via `docker compose`)
 
 ## Konfiguration
-| Variable   | Standardwert             | Beschreibung |
-|------------|--------------------------|--------------|
-| `PORT`     | `3000`                   | HTTP-Port der API |
-| `DB_PATH`  | `./data/app.db`          | Pfad zur SQLite-Datenbank |
-| `REDIS_URL`| `redis://redis:6379`     | Verbindung zur Redis-Instanz |
+| Variable                     | Standardwert       | Beschreibung |
+|------------------------------|--------------------|--------------|
+| `PORT`                       | `3000`             | HTTP-Port der API |
+| `DB_PATH`                    | `./data/app.db`    | Pfad zur SQLite-Datenbank |
+| `REDIS_URL`                  | `redis://redis:6379` | Verbindung zur Redis-Instanz |
+| `BATCH_COUNT_MAX`            | `1000`             | Maximale Anzahl an Levels pro Batch-Auftrag |
+| `MAX_PARALLEL_JOBS`          | `8`                | Obergrenze gleichzeitiger Queue-Starts beim Batch-Enqueue |
+| `JOB_QUEUE_BACKPRESSURE_MS`  | `100`              | Wartezeit bei erreichten Parallelitätsgrenzen (Backpressure) |
+| `REQUEST_BODY_LIMIT_BYTES`   | `65536`            | Maximale Größe eines Request-Bodys |
+| `BATCH_TTL_DAYS`             | `30`               | Aufbewahrungsdauer für Batch-Metadaten bei Listenabfragen |
+| `BATCH_RATE_MAX`             | `5`                | Token-Bucket-Limit für `POST /levels/generate-batch` |
+| `BATCH_RATE_WINDOW_MS`       | `60000`            | Fenstergröße für das Batch-Rate-Limit |
 
 ## Wichtige Skripte
 ```bash
@@ -75,6 +82,84 @@ curl -X POST http://localhost:3000/levels/generate \
   -d '{"seed":"s1","difficulty":1,"abilities":{"run":true,"jump":true}}'
 # {"jobId":"<uuid>"}
 ```
+
+### `POST /levels/generate-batch`
+Erzeugt eine ganze Serie von Generierungsjobs in einem Request. Optional können Seeds, Start-Level, Idempotency-Key, Fähigkeiten
+und Schwierigkeitsprofile (fix oder Rampen) gesetzt werden. Die API antwortet sofort mit `batch_id`, Job-IDs und Anzahl.
+
+**curl-Beispiel**
+```bash
+curl -X POST http://localhost:3000/levels/generate-batch \
+  -H "content-type: application/json" \
+  -d '{
+        "count": 3,
+        "start_level": 12,
+        "seed_prefix": "demo",
+        "difficulty_mode": "ramp",
+        "difficulty_ramp": {"from": 2, "to": 6, "steps": "auto"},
+        "idempotency_key": "demo-123"
+      }'
+# {"batch_id":"...","job_ids":["...","...","..."],"count":3}
+```
+
+**PowerShell**
+```powershell
+$body = @{ count = 2; seed_prefix = 'ps-demo'; idempotency_key = 'batch-ps-1' } | ConvertTo-Json -Depth 4
+Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/levels/generate-batch' -ContentType 'application/json' -Body $body
+```
+
+**JavaScript (fetch)**
+```js
+const response = await fetch('http://localhost:3000/levels/generate-batch', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ count: 5, seed_prefix: 'web-demo', idempotency_key: 'web-42' }),
+});
+const result = await response.json();
+```
+
+### `GET /batches/{id}`
+Liefert Status, Metriken und Fehler eines Batch-Auftrags. Aggregiert den Fortschritt aller Jobs (`queued`, `running`, `succeeded`,
+`failed`, `canceled`) und listet erfolgreiche Level-IDs.
+
+```bash
+curl http://localhost:3000/batches/<batchId>
+# {
+#   "batch_id": "...",
+#   "status": "partial",
+#   "metrics": {"total":3,"succeeded":2,"failed":1,"avg_duration_ms":4200},
+#   "jobs": [{"job_id":"...","status":"succeeded","level_id":"lvl-..."}],
+#   "levels": ["lvl-..."],
+#   "errors": [{"job_id":"...","message":"boom"}]
+# }
+```
+
+### `GET /batches`
+Listet die neuesten Batches (optional paginiert über `limit` und `cursor`). Ein Cursor entspricht dem `created_at`-Zeitstempel
+des letzten Eintrags.
+
+```bash
+curl "http://localhost:3000/batches?limit=10"
+```
+
+Antwort:
+```json
+{
+  "batches": [
+    {
+      "batch_id": "...",
+      "status": "running",
+      "requested_count": 10,
+      "metrics": {"total":10,"queued":4,"running":6,"failed":0,"canceled":0,"avg_duration_ms":null},
+      "request": {"count":10,"seed_prefix":"demo","difficulty_mode":"fixed"}
+    }
+  ],
+  "next_cursor": 1710000000000
+}
+```
+
+> **Idempotenz-Hinweis:** Wird ein `idempotency_key` mehrfach mit identischen Parametern verwendet, liefert die API denselben
+> `batch_id`/`job_ids`-Satz zurück und startet keine neuen Jobs. Abweichende Parameter führen zu `409 idempotency_conflict`.
 
 ### `GET /jobs/:id`
 Abfrage des Jobstatus. Der Generierungs-Job erzeugt im Erfolgsfall automatisch einen nachgelagerten Test-Job.

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1,0 +1,328 @@
+openapi: 3.1.0
+info:
+  title: Infinite Runner API
+  version: 0.1.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /levels/generate:
+    post:
+      summary: Queue a single level generation job
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateRequest'
+      responses:
+        '202':
+          description: Job accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateResponse'
+        '429':
+          description: Rate limited
+  /levels/generate-batch:
+    post:
+      summary: Queue a batch of level generation jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchGenerateRequest'
+      responses:
+        '202':
+          description: Batch accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchGenerateResponse'
+        '200':
+          description: Idempotent replay
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchGenerateResponse'
+        '400':
+          description: Validation error
+        '409':
+          description: Idempotency conflict
+        '429':
+          description: Rate limited
+  /batches/{id}:
+    get:
+      summary: Inspect a batch and its jobs
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Batch detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchDetailResponse'
+        '404':
+          description: Batch not found
+  /batches:
+    get:
+      summary: List batches with metrics
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+        - in: query
+          name: cursor
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Batch list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchListResponse'
+components:
+  schemas:
+    Ability:
+      type: object
+      required:
+        - run
+        - jump
+      properties:
+        run:
+          type: boolean
+          const: true
+        jump:
+          type: boolean
+          const: true
+        highJump:
+          type: boolean
+        shortFly:
+          type: boolean
+        jetpack:
+          type: object
+          properties:
+            fuel:
+              type: integer
+              minimum: 0
+            thrust:
+              type: number
+              minimum: 0
+    GenerateRequest:
+      type: object
+      properties:
+        seed:
+          type: string
+        difficulty:
+          type: integer
+          minimum: 1
+        abilities:
+          $ref: '#/components/schemas/Ability'
+    GenerateResponse:
+      type: object
+      required:
+        - job_id
+      properties:
+        job_id:
+          type: string
+    BatchGenerateRequest:
+      type: object
+      required:
+        - count
+      properties:
+        count:
+          type: integer
+          minimum: 1
+          maximum: 1000
+        start_level:
+          type: integer
+          minimum: 1
+        seed_prefix:
+          type: string
+        season:
+          type: string
+        difficulty_mode:
+          type: string
+          enum: [fixed, ramp]
+          default: fixed
+        difficulty_fixed:
+          type: integer
+          minimum: 1
+        difficulty_ramp:
+          type: object
+          properties:
+            from:
+              type: integer
+              minimum: 1
+            to:
+              type: integer
+              minimum: 1
+            steps:
+              oneOf:
+                - type: string
+                  enum: [auto]
+                - type: integer
+                  minimum: 2
+        abilities:
+          $ref: '#/components/schemas/Ability'
+        constraints:
+          type: object
+          properties:
+            max_moving_platforms:
+              type: integer
+              minimum: 0
+            max_enemies:
+              type: integer
+              minimum: 0
+            max_hazards:
+              type: integer
+              minimum: 0
+        idempotency_key:
+          type: string
+    BatchGenerateResponse:
+      type: object
+      required:
+        - batch_id
+        - job_ids
+        - count
+      properties:
+        batch_id:
+          type: string
+        job_ids:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+    BatchJob:
+      type: object
+      required:
+        - job_id
+        - status
+      properties:
+        job_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, succeeded, failed, canceled]
+        level_id:
+          type: string
+          nullable: true
+        error:
+          type: string
+          nullable: true
+    BatchMetrics:
+      type: object
+      required:
+        - total
+        - queued
+        - running
+        - succeeded
+        - failed
+        - canceled
+      properties:
+        total:
+          type: integer
+        queued:
+          type: integer
+        running:
+          type: integer
+        succeeded:
+          type: integer
+        failed:
+          type: integer
+        canceled:
+          type: integer
+        avg_duration_ms:
+          type: integer
+          nullable: true
+        p95_duration_ms:
+          type: integer
+          nullable: true
+    BatchDetailResponse:
+      type: object
+      required:
+        - batch_id
+        - status
+        - metrics
+        - jobs
+        - levels
+        - errors
+      properties:
+        batch_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, partial, succeeded, failed, canceled]
+        created_at:
+          type: integer
+        updated_at:
+          type: integer
+        request:
+          type: object
+          nullable: true
+        metrics:
+          $ref: '#/components/schemas/BatchMetrics'
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/BatchJob'
+        levels:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            type: object
+            required: [job_id, message]
+            properties:
+              job_id:
+                type: string
+              message:
+                type: string
+    BatchListEntry:
+      type: object
+      required:
+        - batch_id
+        - status
+        - requested_count
+        - metrics
+      properties:
+        batch_id:
+          type: string
+        status:
+          type: string
+        created_at:
+          type: integer
+        updated_at:
+          type: integer
+        requested_count:
+          type: integer
+        request:
+          type: object
+          nullable: true
+        metrics:
+          $ref: '#/components/schemas/BatchMetrics'
+    BatchListResponse:
+      type: object
+      required:
+        - batches
+        - next_cursor
+      properties:
+        batches:
+          type: array
+          items:
+            $ref: '#/components/schemas/BatchListEntry'
+        next_cursor:
+          type: integer
+          nullable: true

--- a/apps/api/src/batches.ts
+++ b/apps/api/src/batches.ts
@@ -1,0 +1,222 @@
+import { Ability, getLevelPlan, type AbilityT } from '@ir/game-spec';
+import { z } from 'zod';
+
+import type { AppConfig } from './config';
+
+const AbilityOverrideSchema = z
+  .object({
+    run: z.literal(true).optional(),
+    jump: z.literal(true).optional(),
+    highJump: z.boolean().optional(),
+    shortFly: z.boolean().optional(),
+    jetpack: Ability.shape.jetpack.optional(),
+  })
+  .partial();
+
+const DifficultyRampSchema = z
+  .object({
+    from: z.number().int().min(1),
+    to: z.number().int().min(1),
+    steps: z.union([z.literal('auto'), z.number().int().min(2)]).default('auto'),
+  })
+  .refine((value) => value.to >= value.from, {
+    message: 'invalid_ramp',
+    path: ['to'],
+  });
+
+const ConstraintsSchema = z
+  .object({
+    max_moving_platforms: z.number().int().min(0).optional(),
+    max_enemies: z.number().int().min(0).optional(),
+    max_hazards: z.number().int().min(0).optional(),
+  })
+  .partial();
+
+export interface NormalizedBatchRequest {
+  count: number;
+  startLevel: number;
+  seedPrefix: string;
+  season?: string | null;
+  difficultyMode: 'fixed' | 'ramp';
+  difficultyFixed?: number;
+  difficultyRamp?: { from: number; to: number; steps: number };
+  abilitiesOverride?: z.infer<typeof AbilityOverrideSchema>;
+  constraints?: z.infer<typeof ConstraintsSchema>;
+  idempotencyKey?: string;
+  fingerprint: string;
+}
+
+export interface BatchJobPlan {
+  index: number;
+  seed: string;
+  levelNumber: number;
+  difficulty: number;
+  abilities: AbilityT;
+}
+
+export interface BatchRequestParseResult {
+  normalized: NormalizedBatchRequest;
+  plans: BatchJobPlan[];
+}
+
+function stableClone(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableClone(entry));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      result[key] = stableClone(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(stableClone(value));
+}
+
+function createBatchSchema(countMax: number) {
+  return z
+    .object({
+      count: z.number().int().min(1).max(countMax),
+      start_level: z.number().int().min(1).default(1),
+      seed_prefix: z.string().trim().min(1).max(128).default('seed'),
+      season: z.string().trim().min(1).max(128).optional(),
+      difficulty_mode: z.enum(['fixed', 'ramp']).default('fixed'),
+      difficulty_fixed: z.number().int().min(1).max(100).optional(),
+      difficulty_ramp: DifficultyRampSchema.optional(),
+      abilities: AbilityOverrideSchema.optional(),
+      constraints: ConstraintsSchema.optional(),
+      idempotency_key: z.string().trim().min(1).max(200).optional(),
+    })
+    .refine(
+      (value) => {
+        if (value.difficulty_mode === 'fixed') {
+          return true;
+        }
+        return value.difficulty_ramp !== undefined;
+      },
+      {
+        message: 'missing_ramp',
+        path: ['difficulty_ramp'],
+      },
+    );
+}
+
+function mergeAbilities(
+  base: AbilityT,
+  override?: z.infer<typeof AbilityOverrideSchema>,
+): AbilityT {
+  if (!override) {
+    return Ability.parse(base);
+  }
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) {
+      continue;
+    }
+    merged[key] = value;
+  }
+  if (merged.run !== true) {
+    merged.run = true;
+  }
+  if (merged.jump !== true) {
+    merged.jump = true;
+  }
+  return Ability.parse(merged);
+}
+
+function resolveRampValue(
+  index: number,
+  params: { from: number; to: number; steps: number },
+): number {
+  const steps = Math.max(1, params.steps);
+  if (steps === 1) {
+    return params.to;
+  }
+  const clampedIndex = Math.min(index, steps - 1);
+  const ratio = clampedIndex / (steps - 1);
+  const raw = params.from + (params.to - params.from) * ratio;
+  return Math.max(1, Math.round(raw));
+}
+
+export function parseBatchRequest(payload: unknown, config: AppConfig): BatchRequestParseResult {
+  const schema = createBatchSchema(config.batch.countMax);
+  const parsed = schema.parse(payload ?? {});
+
+  const count = parsed.count;
+
+  const startLevel = parsed.start_level ?? 1;
+  const seedPrefix = parsed.seed_prefix ?? 'seed';
+  const season = parsed.season?.length ? parsed.season : undefined;
+  const difficultyMode = parsed.difficulty_mode ?? 'fixed';
+
+  const ramp =
+    difficultyMode === 'ramp'
+      ? {
+          from: parsed.difficulty_ramp?.from ?? 1,
+          to: parsed.difficulty_ramp?.to ?? parsed.difficulty_ramp?.from ?? 1,
+          steps:
+            parsed.difficulty_ramp?.steps === 'auto'
+              ? count
+              : Math.max(2, parsed.difficulty_ramp?.steps ?? count),
+        }
+      : undefined;
+
+  const difficultyFixed =
+    difficultyMode === 'fixed' ? (parsed.difficulty_fixed ?? undefined) : undefined;
+
+  const normalized: NormalizedBatchRequest = {
+    count,
+    startLevel,
+    seedPrefix,
+    season: season ?? null,
+    difficultyMode,
+    difficultyFixed,
+    difficultyRamp: ramp,
+    abilitiesOverride: parsed.abilities,
+    constraints: parsed.constraints,
+    idempotencyKey: parsed.idempotency_key,
+    fingerprint: '',
+  };
+
+  const canonicalPayload = {
+    count,
+    start_level: startLevel,
+    seed_prefix: seedPrefix,
+    season: season ?? null,
+    difficulty_mode: difficultyMode,
+    difficulty_fixed: difficultyFixed ?? null,
+    difficulty_ramp: ramp ?? null,
+    abilities: parsed.abilities ?? null,
+    constraints: parsed.constraints ?? null,
+  };
+  normalized.fingerprint = stableStringify(canonicalPayload);
+
+  const plans: BatchJobPlan[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const levelNumber = startLevel + index;
+    const plan = getLevelPlan(levelNumber);
+    const ability = mergeAbilities(plan.abilities, parsed.abilities);
+
+    let difficulty: number;
+    if (difficultyMode === 'fixed') {
+      difficulty = difficultyFixed ?? plan.difficultyTarget;
+    } else {
+      difficulty = resolveRampValue(index, ramp!);
+    }
+    if (!Number.isFinite(difficulty) || difficulty <= 0) {
+      difficulty = Math.max(1, Math.round(plan.difficultyTarget));
+    }
+
+    const seed = `${seedPrefix}-${levelNumber}`;
+    plans.push({ index, seed, levelNumber, difficulty, abilities: ability });
+  }
+
+  return { normalized, plans };
+}

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -23,6 +23,9 @@ describe('config', () => {
     expect(config.internalToken).toBe('dev-internal');
     expect(config.queue.prefix).toBe('bull');
     expect(config.queue.budgetUsdPerDay).toBeNull();
+    expect(config.batch.countMax).toBeGreaterThan(0);
+    expect(config.batch.maxParallelJobs).toBeGreaterThan(0);
+    expect(config.batch.rateLimit.max).toBeGreaterThan(0);
     expect(() => requireProdSecrets(config)).not.toThrow();
   });
 
@@ -33,7 +36,9 @@ describe('config', () => {
     const config = loadConfig();
 
     expect(config.internalToken).toBeUndefined();
-    expect(() => requireProdSecrets(config)).toThrowError('INTERNAL_TOKEN must be set in production');
+    expect(() => requireProdSecrets(config)).toThrowError(
+      'INTERNAL_TOKEN must be set in production',
+    );
   });
 
   it('respects provided internal token and budget configuration', () => {
@@ -47,6 +52,7 @@ describe('config', () => {
     expect(config.internalToken).toBe('super-secret');
     expect(config.queue.budgetUsdPerDay).toBe(12.5);
     expect(config.queue.prefix).toBe('staging');
+    expect(config.batch.countMax).toBeGreaterThan(0);
     expect(() => requireProdSecrets(config)).not.toThrow();
   });
 

--- a/apps/api/src/metrics.ts
+++ b/apps/api/src/metrics.ts
@@ -33,11 +33,7 @@ export const queueJobsDurationSeconds = new Histogram({
   registers: [registry],
 });
 
-export function recordQueueOperation(
-  queue: string,
-  status: string,
-  startedAt?: bigint,
-): void {
+export function recordQueueOperation(queue: string, status: string, startedAt?: bigint): void {
   queueJobsTotal.labels(queue, status).inc();
   if (startedAt) {
     const elapsed = Number(process.hrtime.bigint() - startedAt) / 1_000_000_000;

--- a/apps/api/src/queue/index.test.ts
+++ b/apps/api/src/queue/index.test.ts
@@ -7,7 +7,7 @@ import type { Logger } from '@ir/logger';
 let createdQueues: { name: string; opts: { prefix?: string } }[] = [];
 
 vi.mock('bullmq', () => {
-  class QueueMock<T> {
+  class QueueMock {
     name: string;
     opts: { prefix?: string };
     constructor(name: string, opts: { prefix?: string }) {

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -8,19 +8,22 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 
 import { loadConfig } from './config';
 import { migrate } from './db/migrate';
-import { closeDb, openDb } from './db';
+import { closeDb, openDb, findBatchById, insertLevel, listBatchJobs, updateJobStatus } from './db';
 import { buildServer } from './server';
 import type { QueueManager } from './queue';
 
 function createQueueManagerStub(): QueueManager {
   return {
     enqueueGen: vi.fn().mockResolvedValue('job'),
+    enqueuePreparedGenJobs: vi.fn().mockResolvedValue([]),
     isHealthy: vi.fn().mockResolvedValue(true),
     getQueueOverview: vi.fn().mockResolvedValue({
       gen: { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 },
       test: { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 },
     }),
-    getBudgetStatus: vi.fn().mockResolvedValue({ limitUsd: null, remainingUsd: Number.POSITIVE_INFINITY, ok: true }),
+    getBudgetStatus: vi
+      .fn()
+      .mockResolvedValue({ limitUsd: null, remainingUsd: Number.POSITIVE_INFINITY, ok: true }),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -83,6 +86,192 @@ describe('server', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ levels: [] });
+
+    await server.close();
+    redis.disconnect();
+  });
+
+  it('creates a batch and enqueues jobs', async () => {
+    const dbPath = path.join(tempDir, 'app.db');
+    const db = openDb(dbPath);
+    await migrate(db);
+
+    const queueManager = createQueueManagerStub();
+    const enqueueSpy = queueManager.enqueuePreparedGenJobs as unknown as ReturnType<typeof vi.fn>;
+    const redis = new (Redis as unknown as { new (): IORedis })();
+    const logger = createTestLogger();
+
+    const config = loadConfig({
+      NODE_ENV: 'test',
+      PORT: '0',
+      HOST: '127.0.0.1',
+      REDIS_URL: 'redis://localhost:6379',
+      DB_PATH: dbPath,
+      INTERNAL_TOKEN: 'test-token',
+    });
+
+    const server = buildServer({
+      db,
+      redis,
+      queueManager,
+      logger: logger as never,
+      config,
+      internalToken: config.internalToken ?? 'dev-internal',
+    });
+
+    await server.ready();
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/levels/generate-batch',
+      payload: {
+        count: 2,
+        start_level: 5,
+        seed_prefix: 'demo',
+        difficulty_mode: 'fixed',
+        difficulty_fixed: 3,
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    const body = response.json() as { batch_id: string; job_ids: string[]; count: number };
+    expect(body.count).toBe(2);
+    expect(body.job_ids).toHaveLength(2);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+
+    const stored = findBatchById(body.batch_id);
+    expect(stored).not.toBeNull();
+    const jobs = listBatchJobs(body.batch_id);
+    expect(jobs).toHaveLength(2);
+    expect(jobs[0]?.seed).toContain('demo');
+
+    await server.close();
+    redis.disconnect();
+  });
+
+  it('reuses batches when idempotency key matches', async () => {
+    const dbPath = path.join(tempDir, 'app.db');
+    const db = openDb(dbPath);
+    await migrate(db);
+
+    const queueManager = createQueueManagerStub();
+    const enqueueSpy = queueManager.enqueuePreparedGenJobs as unknown as ReturnType<typeof vi.fn>;
+    const redis = new (Redis as unknown as { new (): IORedis })();
+    const logger = createTestLogger();
+
+    const config = loadConfig({
+      NODE_ENV: 'test',
+      PORT: '0',
+      HOST: '127.0.0.1',
+      REDIS_URL: 'redis://localhost:6379',
+      DB_PATH: dbPath,
+      INTERNAL_TOKEN: 'test-token',
+    });
+
+    const server = buildServer({
+      db,
+      redis,
+      queueManager,
+      logger: logger as never,
+      config,
+      internalToken: config.internalToken ?? 'dev-internal',
+    });
+
+    await server.ready();
+
+    const payload = { count: 1, idempotency_key: 'same-key', seed_prefix: 'reuse' };
+    const first = await server.inject({ method: 'POST', url: '/levels/generate-batch', payload });
+    expect(first.statusCode).toBe(202);
+    const firstBody = first.json() as { batch_id: string; job_ids: string[]; count: number };
+    expect(firstBody.job_ids).toHaveLength(1);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+
+    const second = await server.inject({ method: 'POST', url: '/levels/generate-batch', payload });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json() as { batch_id: string; job_ids: string[]; count: number };
+    expect(secondBody.batch_id).toBe(firstBody.batch_id);
+    expect(secondBody.job_ids).toEqual(firstBody.job_ids);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+
+    await server.close();
+    redis.disconnect();
+  });
+
+  it('aggregates batch status for detail view', async () => {
+    const dbPath = path.join(tempDir, 'app.db');
+    const db = openDb(dbPath);
+    await migrate(db);
+
+    const queueManager = createQueueManagerStub();
+    const enqueueSpy = queueManager.enqueuePreparedGenJobs as unknown as ReturnType<typeof vi.fn>;
+    const redis = new (Redis as unknown as { new (): IORedis })();
+    const logger = createTestLogger();
+
+    const config = loadConfig({
+      NODE_ENV: 'test',
+      PORT: '0',
+      HOST: '127.0.0.1',
+      REDIS_URL: 'redis://localhost:6379',
+      DB_PATH: dbPath,
+      INTERNAL_TOKEN: 'test-token',
+    });
+
+    const server = buildServer({
+      db,
+      redis,
+      queueManager,
+      logger: logger as never,
+      config,
+      internalToken: config.internalToken ?? 'dev-internal',
+    });
+
+    await server.ready();
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/levels/generate-batch',
+      payload: { count: 2, seed_prefix: 'metrics', difficulty_mode: 'fixed', difficulty_fixed: 2 },
+    });
+    expect(response.statusCode).toBe(202);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    const body = response.json() as { batch_id: string; job_ids: string[] };
+    expect(body.job_ids).toHaveLength(2);
+
+    insertLevel(
+      {
+        id: 'lvl-success',
+        seed: 'seed-success',
+        rules: {
+          abilities: { run: true, jump: true },
+          duration_target_s: 60,
+          difficulty: 2,
+        },
+        tiles: [],
+        moving: [],
+        items: [],
+        enemies: [],
+        checkpoints: [],
+        exit: { x: 0, y: 0 },
+      },
+      { difficulty: 2, seed: 'seed-success' },
+    );
+
+    updateJobStatus(body.job_ids[0] ?? '', 'succeeded', { levelId: 'lvl-success' });
+    updateJobStatus(body.job_ids[1] ?? '', 'failed', { error: 'boom' });
+
+    const detail = await server.inject({ method: 'GET', url: `/batches/${body.batch_id}` });
+    expect(detail.statusCode).toBe(200);
+    const detailBody = detail.json() as {
+      status: string;
+      metrics: { succeeded: number; failed: number; total: number };
+      levels: string[];
+      errors: Array<{ job_id: string }>;
+    };
+    expect(detailBody.metrics.total).toBe(2);
+    expect(detailBody.metrics.succeeded).toBe(1);
+    expect(detailBody.metrics.failed).toBe(1);
+    expect(detailBody.levels).toContain('lvl-success');
+    expect(detailBody.errors).toHaveLength(1);
 
     await server.close();
     redis.disconnect();


### PR DESCRIPTION
## Problem
- Einzelne Levelgeneration verursacht hohen Overhead bei großen Serien.
- Es fehlte eine API, die mehrere Jobs atomar anlegt, Idempotenz sicherstellt und Fortschritt aggregiert.
- Dokumentation und OpenAPI spiegelten die Batch-Funktionalität nicht wider.

## Lösung
- Neues Batch-Subsystem mit Parser, Seed-/Schwierigkeitsplanung, Queue-Integration und Statusaggregation implementiert.
- Routen `/levels/generate-batch`, `/batches/:id` und `/batches` im Server registriert und mit Rate-Limit, Idempotenz sowie Fehlerpfaden versehen.
- Datenbank um `batches` und `batch_jobs` erweitert, inklusive Status-Recomputing und Dauer-Metriken.
- Konfigurationsschema erweitert (Limits, Rate-Limits, Body-Limit) und Tests aktualisiert.
- README sowie OpenAPI-Spezifikation mit Batch-Beispielen, Parametern und Antwortschemas ergänzt.

## Neue Endpunkte
- `POST /levels/generate-batch`
- `GET /batches/{id}`
- `GET /batches`

## Neue Config-Keys
- `BATCH_COUNT_MAX`
- `MAX_PARALLEL_JOBS`
- `JOB_QUEUE_BACKPRESSURE_MS`
- `REQUEST_BODY_LIMIT_BYTES`
- `BATCH_TTL_DAYS`
- `BATCH_RATE_MAX`
- `BATCH_RATE_WINDOW_MS`

## Migration
- Neue Tabellen `batches` und `batch_jobs` (Migration in `apps/api/src/db/migrate.ts`).

## Risiken
- Größere Batch-Listen laden derzeit alle Jobdatensätze – bei sehr vielen Batches eventuell Optimierung nötig.
- Worker verarbeitet zusätzliche Metadaten noch nicht aktiv (Folgetasks möglich).


------
https://chatgpt.com/codex/tasks/task_e_68e0fce9e2f0832d8fe44225196122ca