### PR TITLE
feat: centralize structured logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ yarn-error.log*
 .env.*.local
 
 # Logs
-logs
+logs/
 .logs/
 *.pid
 *.seed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fastify/cors": "^8.4.2",
     "@ir/game-spec": "workspace:^",
-    "@ir/logger": "workspace:^",
+    "@pkg/logger": "workspace:^",
     "better-sqlite3": "^9.4.0",
     "bullmq": "^5.12.0",
     "dotenv": "^16.6.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import IORedis from 'ioredis';
 import process from 'node:process';
 
-import { createLogger, bindUnhandled } from '@ir/logger';
+import { makeLogger } from '@pkg/logger';
 
 import { loadConfig, requireProdSecrets } from './config';
 import { openDb } from './db';
@@ -13,8 +13,7 @@ import { buildServer } from './server';
 dotenv.config();
 
 async function bootstrap() {
-  const logger = createLogger('api');
-  bindUnhandled(logger);
+  const logger = makeLogger('api');
 
   const config = loadConfig();
   requireProdSecrets(config);
@@ -133,7 +132,7 @@ async function main() {
   try {
     await bootstrap();
   } catch (error) {
-    const logger = createLogger('api');
+    const logger = makeLogger('api');
     logger.fatal({ err: error }, 'Fatal error during bootstrap');
     process.exit(1);
   }

--- a/apps/api/src/queue/index.test.ts
+++ b/apps/api/src/queue/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 
 import { resolveQueueConfig } from '@ir/queue-config';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 let createdQueues: { name: string; opts: { prefix?: string } }[] = [];
 

--- a/apps/api/src/queue/index.ts
+++ b/apps/api/src/queue/index.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Ability } from '@ir/game-spec';
 import { resolveQueueConfig } from '@ir/queue-config';
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 import { z } from 'zod';
 
 import { insertJob, updateJobStatus, upsertSeasonJob } from '../db';

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "dev:up": "powershell -ExecutionPolicy Bypass -File scripts/dev-up.ps1",
     "dev:down": "powershell -ExecutionPolicy Bypass -File scripts/dev-down.ps1",
     "prod:up": "powershell -ExecutionPolicy Bypass -File scripts/prod-up.ps1",
-    "prod:down": "powershell -ExecutionPolicy Bypass -File scripts/prod-down.ps1"
+    "prod:down": "powershell -ExecutionPolicy Bypass -File scripts/prod-down.ps1",
+    "logs:clean": "node ./scripts/clean-logs.mjs",
+    "logs:tail:api": "node ./scripts/tail-log.mjs api",
+    "logs:tail:playtester": "node ./scripts/tail-log.mjs playtester"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.8.0",

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,1 +1,1 @@
-export * from './src/index.js';
+export * from './src/index.ts';

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ir/logger",
-  "version": "0.1.0",
+  "name": "@pkg/logger",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "exports": {

--- a/scripts/clean-logs.mjs
+++ b/scripts/clean-logs.mjs
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const logDirEnv = process.env.LOG_DIR?.trim();
+const repoRoot = process.cwd();
+const logRoot = logDirEnv && logDirEnv.length > 0 ? path.resolve(logDirEnv) : path.join(repoRoot, 'logs');
+
+if (!fs.existsSync(logRoot)) {
+  console.log(`No logs directory at ${logRoot}`);
+  process.exit(0);
+}
+
+fs.rmSync(logRoot, { recursive: true, force: true });
+console.log(`Removed log directory: ${logRoot}`);

--- a/scripts/tail-log.mjs
+++ b/scripts/tail-log.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const service = process.argv[2];
+if (!service) {
+  console.error('Usage: node scripts/tail-log.mjs <service>');
+  process.exit(1);
+}
+
+const logDirEnv = process.env.LOG_DIR?.trim();
+const repoRoot = process.cwd();
+const logRoot = logDirEnv && logDirEnv.length > 0 ? path.resolve(logDirEnv) : path.join(repoRoot, 'logs');
+const serviceDir = path.join(logRoot, service);
+
+if (!fs.existsSync(serviceDir)) {
+  console.error(`No log directory for service '${service}' at ${serviceDir}`);
+  process.exit(1);
+}
+
+const files = fs
+  .readdirSync(serviceDir)
+  .filter((file) => file.startsWith('run-') && file.endsWith('.log'))
+  .sort();
+
+const latest = files.at(-1);
+if (!latest) {
+  console.error(`No run logs found for service '${service}' in ${serviceDir}`);
+  process.exit(1);
+}
+
+const filePath = path.join(serviceDir, latest);
+console.log(`Tailing ${filePath}`);
+
+let position = 0;
+
+function readFrom(offset) {
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8', start: offset });
+  stream.on('data', (chunk) => {
+    position += Buffer.byteLength(chunk);
+    process.stdout.write(chunk);
+  });
+}
+
+readFrom(0);
+
+fs.watch(filePath, (eventType) => {
+  if (eventType !== 'change') {
+    return;
+  }
+  try {
+    const stats = fs.statSync(filePath);
+    if (stats.size <= position) {
+      return;
+    }
+    readFrom(position);
+  } catch (error) {
+    console.error('Failed to read updated log file:', error);
+  }
+});

--- a/services/playtester/package.json
+++ b/services/playtester/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@ir/game-spec": "workspace:^",
-    "@ir/logger": "workspace:^",
+    "@pkg/logger": "workspace:^",
     "bullmq": "^5.12.0",
     "dotenv": "^16.4.5",
     "fast-json-stable-stringify": "^2.1.0",

--- a/services/playtester/src/generator.ts
+++ b/services/playtester/src/generator.ts
@@ -13,7 +13,7 @@ import stringify from 'fast-json-stable-stringify';
 import seedrandom from 'seedrandom';
 import { z } from 'zod';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 import { getOpenAIClient, getRedisClient, closeClients, getModel } from './clients';
 import { trackAndCheck } from './costguard';

--- a/services/playtester/src/http.ts
+++ b/services/playtester/src/http.ts
@@ -1,6 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 import { cfg } from './config';
 

--- a/services/playtester/src/index.ts
+++ b/services/playtester/src/index.ts
@@ -1,11 +1,8 @@
 import 'dotenv/config';
 
-import { createLogger } from '@ir/logger';
-
 import { cfg } from './config';
 import { startWorkers, stopWorkers } from './queue';
-
-const logger = createLogger('playtester');
+import { logger } from './logger';
 
 async function main() {
   logger.info(

--- a/services/playtester/src/logger.ts
+++ b/services/playtester/src/logger.ts
@@ -1,0 +1,5 @@
+import { makeLogger } from '@pkg/logger';
+
+export const logger = makeLogger('playtester');
+
+export type Logger = typeof logger;

--- a/services/playtester/src/tester.test.ts
+++ b/services/playtester/src/tester.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LevelT } from '@ir/game-spec';
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 const hazardLevel: LevelT = {
   id: 'hazard-test',

--- a/services/playtester/src/tester.ts
+++ b/services/playtester/src/tester.ts
@@ -1,6 +1,6 @@
 import { LevelT, getLevelPlan } from '@ir/game-spec';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 import { InputCmd, InputState, createSpawn, maxJumpGapPX, simulate } from './sim/arcade';
 import { findPath } from './sim/search';

--- a/services/playtester/src/tuner.test.ts
+++ b/services/playtester/src/tuner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { LevelT } from '@ir/game-spec';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 import { tune } from './tuner';
 

--- a/services/playtester/src/tuner.ts
+++ b/services/playtester/src/tuner.ts
@@ -1,6 +1,6 @@
 import { Level, LevelT } from '@ir/game-spec';
 
-import type { Logger } from '@ir/logger';
+import type { Logger } from '@pkg/logger';
 
 import { Fail, GapDetail, HazardDetail } from './tester';
 

--- a/services/playtester/vitest.setup.ts
+++ b/services/playtester/vitest.setup.ts
@@ -14,7 +14,7 @@ vi.mock('openai', () => {
   return { OpenAI: FakeClient };
 });
 
-vi.mock('@ir/logger', () => {
+vi.mock('@pkg/logger', () => {
   const noop = () => undefined;
   const logger: Record<string, unknown> = {
     info: vi.fn(noop),
@@ -25,8 +25,11 @@ vi.mock('@ir/logger', () => {
     fatal: vi.fn(noop),
   };
   (logger as { child: ReturnType<typeof vi.fn> }).child = vi.fn(() => logger);
+  (logger as { flush: ReturnType<typeof vi.fn> }).flush = vi.fn();
 
   return {
-    createLogger: vi.fn(() => logger),
+    makeLogger: vi.fn(() => logger),
+    getLogFilePath: vi.fn(() => null),
+    closeLogger: vi.fn(),
   };
 });


### PR DESCRIPTION
## Summary
- add a shared `@pkg/logger` package that writes JSON log lines to per-service run files, supports optional clean-start behaviour, and hooks unhandled errors/signals
- switch the API and playtester to the shared logger, expanding request/queue/job logging and adding Redis/OpenAI telemetry
- document the logging workflow, add helper scripts for cleaning/tailing logs, and ignore the new `logs/` directory

## Testing
- pnpm --filter api exec vitest run *(fails: command "vitest" not found in environment)*
- pnpm --filter @srv/playtester exec vitest run *(fails: command "vitest" not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e106700134832d94b5021a69298448